### PR TITLE
Add the ability to deprecate fields (can't be deleted once released)

### DIFF
--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -33,6 +33,7 @@ public with sharing class frSetupController {
 
 		Map<String, Schema.SObjectField> oppFields = Opportunity.sObjectType.getDescribe().fields.getMap();
 		for(String fieldName : oppFields.keySet()) {
+			if(fieldName.startsWith('funraise__')) continue; //skip any fields that are part of the managed package
 			Schema.DescribeFieldResult describe = oppFields.get(fieldName).getDescribe();
 			if(describe.isUpdateable()) {
 				donationSFOptions.add(new SelectOption(fieldName, describe.getLabel()));
@@ -46,6 +47,7 @@ public with sharing class frSetupController {
 
 		Map<String, Schema.SObjectField> contactFields = Contact.sObjectType.getDescribe().fields.getMap();
 		for(String fieldName : contactFields.keySet()) {
+			if(fieldName.startsWith('funraise__')) continue; //skip any fields that are part of the managed package
 			Schema.DescribeFieldResult describe = contactFields.get(fieldName).getDescribe();
 			if(describe.isUpdateable()) {
 				donorSFOptions.add(new SelectOption(fieldName, describe.getLabel()));

--- a/src/customMetadata/frField.allocations.md
+++ b/src/customMetadata/frField.allocations.md
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Address 2</label>
+    <label>Allocations</label>
     <protected>false</protected>
     <values>
         <field>Type__c</field>
-        <value xsi:type="xsd:string">Deprecated</value>
+        <value xsi:type="xsd:string">Donation</value>
     </values>
 </CustomMetadata>

--- a/src/customMetadata/frField.pledge.md
+++ b/src/customMetadata/frField.pledge.md
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Address 2</label>
+    <label>Is Pledge</label>
     <protected>false</protected>
     <values>
         <field>Type__c</field>
-        <value xsi:type="xsd:string">Deprecated</value>
+        <value xsi:type="xsd:string">Donation</value>
     </values>
 </CustomMetadata>

--- a/src/objects/frField__mdt.object
+++ b/src/objects/frField__mdt.object
@@ -15,6 +15,10 @@
                 <fullName>Donation</fullName>
                 <default>false</default>
             </picklistValues>
+            <picklistValues>
+                <fullName>Deprecated</fullName>
+                <default>false</default>
+            </picklistValues>
             <restrictedPicklist>true</restrictedPicklist>
             <sorted>false</sorted>
         </picklist>

--- a/src/objects/frMapping__c.object
+++ b/src/objects/frMapping__c.object
@@ -4,6 +4,7 @@
     <enableFeeds>false</enableFeeds>
     <fields>
         <fullName>Constant_Value__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Constant Value</label>
         <length>255</length>
@@ -15,6 +16,7 @@
     <fields>
         <fullName>Is_Constant__c</fullName>
         <defaultValue>false</defaultValue>
+        <deprecated>false</deprecated>
         <description>Defines whether or not this mapping should use a value from the Funraise platform (false) or a constant value (true)</description>
         <externalId>false</externalId>
         <label>Is Constant</label>


### PR DESCRIPTION
Deprecate address2, add allocations and pledge fields on donation.  Also
don't allow any mappings to managed package fields (like fr_id or
fr_donor_id because those are managed by us behind the scenes)