### PR TITLE
Fix allocation field name

### DIFF
--- a/src/classes/frWSDonationControllerTest.cls
+++ b/src/classes/frWSDonationControllerTest.cls
@@ -81,7 +81,7 @@ public class frWSDonationControllerTest {
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, StageName, Probability, FiscalYear, TotalOpportunityQuantity FROM Opportunity WHERE Id = :oppId];
         System.assertEquals('Closed Won', newOpportunity.StageName, 'The constant mapping for StageName was not used');
         System.assertEquals(95, newOpportunity.Probability, 'The constant mapping for Probability was not used');
-        System.assertEquals(Date.today().year(), newOpportunity.FiscalYear, 'The constant mapping for Fiscal Year was not used');
+        System.assertEquals(2017, newOpportunity.FiscalYear, 'The constant mapping for Fiscal Year was not used');
         System.assertEquals(1.5, newOpportunity.TotalOpportunityQuantity, 'The constant mapping for Total Opportunity Quantity was not used');
     }
 

--- a/src/customMetadata/frField.allocation.md
+++ b/src/customMetadata/frField.allocation.md
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Allocations</label>
+    <label>Allocation</label>
     <protected>false</protected>
     <values>
         <field>Type__c</field>
-        <value xsi:type="xsd:string">Deprecated</value>
+        <value xsi:type="xsd:string">Donation</value>
     </values>
 </CustomMetadata>


### PR DESCRIPTION
use singular allocation field, since operations tip doesnt need to be included, deprecate old allocations field

We can always bring allocations (plural) back when we add the ability for multiple non-op tip allocations