### PR TITLE
Adding /donoremail endpoint that adds emails to a contact as activity

### DIFF
--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -7,15 +7,21 @@ public class frDonorEmails {
 
     public void parseEmails(Map<String, Object> request, String contactId) {
         try {
-            System.debug('Creating new event');
-            Event ev = new Event();
-            ev.fr_Email_ID__c = String.valueOf(request.get('emailId'));
-            System.debug('Email ID' + ev.fr_Email_ID__c);
-            ev.ActivityDateTime = DateTime.newInstance((Long)request.get('sentDate')).dateGMT();
-            ev.WhoId = contactId;
-            ev.Subject = 'Funraise Email - ' + String.valueOf(request.get('subject'));
-            ev.DurationInMinutes = 1;
-            Database.upsert(ev, Event.Fields.fr_Email_ID__c, true);
+            EmailMessage email = new EmailMessage();
+            email.Status = '3';
+            email.FromAddress = String.valueOf(request.get('fromAddress'));
+            email.FromName = String.valueOf(request.get('fromName'));
+            email.toIds = new String[]{contactId};
+            email.subject = 'Funraise Email - ' + String.valueOf(request.get('subject'));
+            email.MessageDate = DateTime.newInstance((Long)request.get('sentDate')).dateGMT();
+            email.fr_Email_ID__c = String.valueOf(request.get('emailId'));
+            insert email;
+
+            EmailMessageRelation emr = new EmailMessageRelation();
+            emr.EmailMessageId = email.Id;
+            emr.RelationId = contactId;
+            emr.RelationType = 'ToAddress';
+            insert emr;
         } catch (DMLException e) {
         	insert new Error__c(Error__c = e.getMessage());
         }
@@ -23,14 +29,12 @@ public class frDonorEmails {
 
     public static String create(Map<String, Object> request) {
         String frId = String.valueOf(request.get('id'));
-        System.debug('Looking for donor');
 
         // Try to find a donor that's already been integrated, use their funraise ID
         frDonor donor = frDonor.findByFunraiseId(frId);
 
         // If we don't a donor we will not add the emails
         if (donor != null) {
-            System.debug('Donor found');
             frDonorEmails donorEmails = new frDonorEmails(donor);
             donorEmails.parseEmails(request, donor.getContactId());
 

--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -1,0 +1,69 @@
+public class frDonorEmails extends frModel {
+    public static final String TYPE = 'DonorEmails';
+
+    public static List<frMapping__c> mappings {
+        get {
+            if(mappings == null) {
+                mappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Type__c FROM frMapping__c WHERE Type__c = :TYPE ORDER BY CreatedDate];
+            }
+            return mappings;
+        }
+        set;
+    }
+
+    protected override SObject getObject() {
+        return d.getContact();
+    }
+
+    public override List<frMapping__c> getMappings() {
+        return mappings;
+    }
+
+    private String contactId;
+    private frDonor d;
+
+    public frDonorEmails(frDonor d) {
+        this.contactId = d.getContactId();
+        this.d = d;
+    }
+
+    public void parseEmails(Map<String, Object> request) {
+        Map<String, Object> emails = (Map<String, Object>)request.get('emails');
+        try {
+            List<Event> eventList = new List<Event>();
+            for (String s : emails.keySet()) {
+                Map<String, Object> e = (Map<String, Object>)emails.get(s);
+                Event ev = new Event();
+                ev.fr_Email_ID__c = String.valueOf(e.get('emailId'));
+                ev.ActivityDateTime = DateTime.newInstance((Long)e.get('sentDate')).dateGMT();
+                ev.WhoId = contactId;
+                ev.Subject = 'Funraise Email - ' + String.valueOf(e.get('subject'));
+                ev.DurationInMinutes = 1;
+                eventList.add(ev);
+            }
+            Database.upsert(eventList, Event.Fields.fr_Email_ID__c, true);
+        } catch (DMLException e) {
+            handleException(e);
+        }
+    }
+
+    public static frDonorEmails create(Map<String, Object> request) {
+        String frId = String.valueOf(request.get('id'));
+
+        // Try to find a donor that's already been integrated, use their funraise ID
+        frDonor donor = frDonor.findByFunraiseId(frId);
+
+        // If we don't a donor we will not add the emails
+        if (donor != null) {
+            frDonorEmails donorEmails = new frDonorEmails(donor);
+            donorEmails.parseEmails(request);
+
+            return donorEmails;
+        }
+        return null;
+    }
+
+    public String getContactId() {
+        return this.contactId;
+    }
+}

--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -1,24 +1,4 @@
-public class frDonorEmails extends frModel {
-    public static final String TYPE = 'DonorEmails';
-
-    public static List<frMapping__c> mappings {
-        get {
-            if(mappings == null) {
-                mappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Type__c FROM frMapping__c WHERE Type__c = :TYPE ORDER BY CreatedDate];
-            }
-            return mappings;
-        }
-        set;
-    }
-
-    protected override SObject getObject() {
-        return d.getContact();
-    }
-
-    public override List<frMapping__c> getMappings() {
-        return mappings;
-    }
-
+public class frDonorEmails {
     private frDonor d;
 
     public frDonorEmails(frDonor d) {
@@ -41,7 +21,7 @@ public class frDonorEmails extends frModel {
             }
             Database.upsert(eventList, Event.Fields.fr_Email_ID__c, true);
         } catch (DMLException e) {
-            handleException(e);
+        	insert new Error__c(Error__c = e.getMessage());
         }
     }
 
@@ -58,6 +38,6 @@ public class frDonorEmails extends frModel {
 
             return donor.getContactId();
         }
-        return '-1';
+        return null;
     }
 }

--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -6,20 +6,16 @@ public class frDonorEmails {
     }
 
     public void parseEmails(Map<String, Object> request, String contactId) {
-        Map<String, Object> emails = (Map<String, Object>)request.get('emails');
         try {
-            List<Event> eventList = new List<Event>();
-            for (String s : emails.keySet()) {
-                Map<String, Object> e = (Map<String, Object>)emails.get(s);
-                Event ev = new Event();
-                ev.fr_Email_ID__c = String.valueOf(e.get('emailId'));
-                ev.ActivityDateTime = DateTime.newInstance((Long)e.get('sentDate')).dateGMT();
-                ev.WhoId = contactId;
-                ev.Subject = 'Funraise Email - ' + String.valueOf(e.get('subject'));
-                ev.DurationInMinutes = 1;
-                eventList.add(ev);
-            }
-            Database.upsert(eventList, Event.Fields.fr_Email_ID__c, true);
+            System.debug('Creating new event');
+            Event ev = new Event();
+            ev.fr_Email_ID__c = String.valueOf(request.get('emailId'));
+            System.debug('Email ID' + ev.fr_Email_ID__c);
+            ev.ActivityDateTime = DateTime.newInstance((Long)request.get('sentDate')).dateGMT();
+            ev.WhoId = contactId;
+            ev.Subject = 'Funraise Email - ' + String.valueOf(request.get('subject'));
+            ev.DurationInMinutes = 1;
+            Database.upsert(ev, Event.Fields.fr_Email_ID__c, true);
         } catch (DMLException e) {
         	insert new Error__c(Error__c = e.getMessage());
         }
@@ -27,12 +23,14 @@ public class frDonorEmails {
 
     public static String create(Map<String, Object> request) {
         String frId = String.valueOf(request.get('id'));
+        System.debug('Looking for donor');
 
         // Try to find a donor that's already been integrated, use their funraise ID
         frDonor donor = frDonor.findByFunraiseId(frId);
 
         // If we don't a donor we will not add the emails
         if (donor != null) {
+            System.debug('Donor found');
             frDonorEmails donorEmails = new frDonorEmails(donor);
             donorEmails.parseEmails(request, donor.getContactId());
 

--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -19,15 +19,13 @@ public class frDonorEmails extends frModel {
         return mappings;
     }
 
-    private String contactId;
     private frDonor d;
 
     public frDonorEmails(frDonor d) {
-        this.contactId = d.getContactId();
         this.d = d;
     }
 
-    public void parseEmails(Map<String, Object> request) {
+    public void parseEmails(Map<String, Object> request, String contactId) {
         Map<String, Object> emails = (Map<String, Object>)request.get('emails');
         try {
             List<Event> eventList = new List<Event>();
@@ -47,7 +45,7 @@ public class frDonorEmails extends frModel {
         }
     }
 
-    public static frDonorEmails create(Map<String, Object> request) {
+    public static String create(Map<String, Object> request) {
         String frId = String.valueOf(request.get('id'));
 
         // Try to find a donor that's already been integrated, use their funraise ID
@@ -56,14 +54,10 @@ public class frDonorEmails extends frModel {
         // If we don't a donor we will not add the emails
         if (donor != null) {
             frDonorEmails donorEmails = new frDonorEmails(donor);
-            donorEmails.parseEmails(request);
+            donorEmails.parseEmails(request, donor.getContactId());
 
-            return donorEmails;
+            return donor.getContactId();
         }
-        return null;
-    }
-
-    public String getContactId() {
-        return this.contactId;
+        return '-1';
     }
 }

--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -1,11 +1,6 @@
 public class frDonorEmails {
-    private frDonor d;
 
-    public frDonorEmails(frDonor d) {
-        this.d = d;
-    }
-
-    public void parseEmails(Map<String, Object> request, String contactId) {
+    public static void parseEmails(Map<String, Object> request, String contactId) {
         try {
             EmailMessage email = new EmailMessage();
             email.Status = '3';
@@ -35,8 +30,7 @@ public class frDonorEmails {
 
         // If we don't a donor we will not add the emails
         if (donor != null) {
-            frDonorEmails donorEmails = new frDonorEmails(donor);
-            donorEmails.parseEmails(request, donor.getContactId());
+            frDonorEmails.parseEmails(request, donor.getContactId());
 
             return donor.getContactId();
         }

--- a/src/classes/frDonorEmails.cls-meta.xml
+++ b/src/classes/frDonorEmails.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>43.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -53,6 +53,9 @@ public class frDonorEmailsTest {
         request.put('emailId', 4);
         request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
         request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        request.put('fromAddress', 'test@funraise.io');
+        request.put('fromName', 'Bob Hope');
+        request.put('toAddress', 'notfunraise@funraise.io');
         request.put('statusCode', 202);
         request.put('sentDate', 1536184380L);
         request.put('subject', 'Hello there!');
@@ -62,35 +65,9 @@ public class frDonorEmailsTest {
         Test.stopTest();
 
         Contact[] newContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_ID__c = :funraiseId];
-        Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :newContact[0].Id];
-        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
-    }
-
-    static testMethod void createExistingContactMultipleEmails_test() {
-        String funraiseId = '123456';
-        Contact testContact = new Contact(
-            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
-            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ',
-            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = funraiseId
-        );
-        insert testContact;
-
-        Map<String, Object> request = new Map<String, Object>();
-        request.put('id', funraiseId);
-        request.put('emailId', 4);
-        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        request.put('statusCode', 202);
-        request.put('sentDate', 1536184380L);
-        request.put('subject', 'Hello there!');
-
-        Test.startTest();
-        String donorEmailsResponse = frDonorEmails.create(request);
-        Test.stopTest();
-
-        Contact[] newContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_ID__c = :funraiseId];
-        Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :newContact[0].Id];
-        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
+        String[] toAddress = new String[]{'notfunraise@funraise.io'};
+        EmailMessage newEmail = [SELECT fromAddress FROM EmailMessage WHERE fr_Email_ID__c = '4'];
+        System.assertEquals('test@funraise.io', newEmail.fromAddress, 'The fromAddress was not correct');
     }
 
     static testMethod void createNoExistingContact_test() {

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -50,16 +50,12 @@ public class frDonorEmailsTest {
 
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', funraiseId);
-        Map<String, Object> email = new Map<String, Object>();
-        email.put('emailId', 4);
-        email.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        email.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        email.put('statusCode', 202);
-        email.put('sentDate', 1536184380L);
-        email.put('subject', 'Hello there!');
-        Map<String, Object> emailMap = new Map<String, Object>();
-        emailMap.put('db92570b-766b-46b9-8b7a-a0c7efa92053', email);
-        request.put('emails', emailMap);
+        request.put('emailId', 4);
+        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
+        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        request.put('statusCode', 202);
+        request.put('sentDate', 1536184380L);
+        request.put('subject', 'Hello there!');
 
         Test.startTest();
         String donorEmailsResponse = frDonorEmails.create(request);
@@ -81,23 +77,12 @@ public class frDonorEmailsTest {
 
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', funraiseId);
-        Map<String, Object> email1 = new Map<String, Object>();
-        email1.put('emailId', 4);
-        email1.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        email1.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        email1.put('statusCode', 202);
-        email1.put('sentDate', 1536184380L);
-        email1.put('subject', 'Hello there!');
-        Map<String, Object> email2 = new Map<String, Object>();
-        email2.put('emailId', 2);
-        email2.put('messageId', '761aef79-ca2f-48aa-bdef-4580eca7aaf6');
-        email2.put('correlationId', '9VbkmOG1Q9KLI_rleHPoDg');
-        email2.put('statusCode', 202);
-        email2.put('sentDate', 1536184380L);
-        email2.put('subject', 'Hello AGAIN!!');
-        Map<String, Object> emailMap = new Map<String, Object>();
-        emailMap.put('761aef79-ca2f-48aa-bdef-4580eca7aaf6', email2);
-        request.put('emails', emailMap);
+        request.put('emailId', 4);
+        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
+        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        request.put('statusCode', 202);
+        request.put('sentDate', 1536184380L);
+        request.put('subject', 'Hello there!');
 
         Test.startTest();
         String donorEmailsResponse = frDonorEmails.create(request);
@@ -105,7 +90,7 @@ public class frDonorEmailsTest {
 
         Contact[] newContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_ID__c = :funraiseId];
         Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :newContact[0].Id];
-        System.assertEquals('2', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
+        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
     }
 
     static testMethod void createNoExistingContact_test() {
@@ -113,16 +98,12 @@ public class frDonorEmailsTest {
 
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', 2314);
-        Map<String, Object> email = new Map<String, Object>();
-        email.put('emailId', 4);
-        email.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        email.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        email.put('statusCode', 202);
-        email.put('sentDate', 1536184380L);
-        email.put('subject', 'Hello there!');
-        Map<String, Object> emailMap = new Map<String, Object>();
-        emailMap.put('db92570b-766b-46b9-8b7a-a0c7efa92053', email);
-        request.put('emails', emailMap);
+        request.put('emailId', 4);
+        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
+        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        request.put('statusCode', 202);
+        request.put('sentDate', 1536184380L);
+        request.put('subject', 'Hello there!');
 
         Test.startTest();
         String donorEmailsResponse = frDonorEmails.create(request);

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -62,7 +62,7 @@ public class frDonorEmailsTest {
         request.put('emails', emailMap);
 
         Test.startTest();
-        frDonorEmails donorEmails = frDonorEmails.create(request);
+        String donorEmailsResponse = frDonorEmails.create(request);
         Test.stopTest();
 
         Contact[] newContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_ID__c = :funraiseId];
@@ -100,12 +100,12 @@ public class frDonorEmailsTest {
         request.put('emails', emailMap);
 
         Test.startTest();
-        frDonorEmails donorEmails = frDonorEmails.create(request);
+        String donorEmailsResponse = frDonorEmails.create(request);
         Test.stopTest();
 
         Contact[] newContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_ID__c = :funraiseId];
         Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :newContact[0].Id];
-        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
+        System.assertEquals('2', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
     }
 
     static testMethod void createNoExistingContact_test() {
@@ -125,9 +125,9 @@ public class frDonorEmailsTest {
         request.put('emails', emailMap);
 
         Test.startTest();
-        frDonorEmails donorEmails = frDonorEmails.create(request);
+        String donorEmailsResponse = frDonorEmails.create(request);
         Test.stopTest();
 
-        System.assertEquals(null, donorEmails, 'The donor emails is not null');
+        System.assertEquals(null, donorEmailsResponse, 'The donor was not null');
     }
 }

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -1,0 +1,133 @@
+/*
+ *
+ *  Copyright (c) 2016, Funraise Inc
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. All advertising materials mentioning features or use of this software
+ *     must display the following acknowledgement:
+ *     This product includes software developed by the <organization>.
+ *  4. Neither the name of the <organization> nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ * PURPOSE:
+ *
+ *
+ *
+ * CREATED: 2018 Funraise Inc - https://funraise.io
+ * AUTHOR: Jordan Speer
+ */
+@isTest
+public class frDonorEmailsTest {
+    static testMethod void createExistingContact_test() {
+        String funraiseId = '123456';
+        Contact testContact = new Contact(
+            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
+            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ',
+            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = funraiseId
+        );
+        insert testContact;
+
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('id', funraiseId);
+        Map<String, Object> email = new Map<String, Object>();
+        email.put('emailId', 4);
+        email.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
+        email.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        email.put('statusCode', 202);
+        email.put('sentDate', 1536184380L);
+        email.put('subject', 'Hello there!');
+        Map<String, Object> emailMap = new Map<String, Object>();
+        emailMap.put('db92570b-766b-46b9-8b7a-a0c7efa92053', email);
+        request.put('emails', emailMap);
+
+        Test.startTest();
+        frDonorEmails donorEmails = frDonorEmails.create(request);
+        Test.stopTest();
+
+        Contact[] newContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_ID__c = :funraiseId];
+        Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :newContact[0].Id];
+        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
+    }
+
+    static testMethod void createExistingContactMultipleEmails_test() {
+        String funraiseId = '123456';
+        Contact testContact = new Contact(
+            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
+            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ',
+            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = funraiseId
+        );
+        insert testContact;
+
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('id', funraiseId);
+        Map<String, Object> email1 = new Map<String, Object>();
+        email1.put('emailId', 4);
+        email1.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
+        email1.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        email1.put('statusCode', 202);
+        email1.put('sentDate', 1536184380L);
+        email1.put('subject', 'Hello there!');
+        Map<String, Object> email2 = new Map<String, Object>();
+        email2.put('emailId', 2);
+        email2.put('messageId', '761aef79-ca2f-48aa-bdef-4580eca7aaf6');
+        email2.put('correlationId', '9VbkmOG1Q9KLI_rleHPoDg');
+        email2.put('statusCode', 202);
+        email2.put('sentDate', 1536184380L);
+        email2.put('subject', 'Hello AGAIN!!');
+        Map<String, Object> emailMap = new Map<String, Object>();
+        emailMap.put('761aef79-ca2f-48aa-bdef-4580eca7aaf6', email2);
+        request.put('emails', emailMap);
+
+        Test.startTest();
+        frDonorEmails donorEmails = frDonorEmails.create(request);
+        Test.stopTest();
+
+        Contact[] newContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_ID__c = :funraiseId];
+        Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :newContact[0].Id];
+        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
+    }
+
+    static testMethod void createNoExistingContact_test() {
+        String funraiseId = '2314';
+
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('id', 2314);
+        Map<String, Object> email = new Map<String, Object>();
+        email.put('emailId', 4);
+        email.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
+        email.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        email.put('statusCode', 202);
+        email.put('sentDate', 1536184380L);
+        email.put('subject', 'Hello there!');
+        Map<String, Object> emailMap = new Map<String, Object>();
+        emailMap.put('db92570b-766b-46b9-8b7a-a0c7efa92053', email);
+        request.put('emails', emailMap);
+
+        Test.startTest();
+        frDonorEmails donorEmails = frDonorEmails.create(request);
+        Test.stopTest();
+
+        System.assertEquals(null, donorEmails, 'The donor emails is not null');
+    }
+}

--- a/src/classes/frDonorEmailsTest.cls-meta.xml
+++ b/src/classes/frDonorEmailsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>43.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frWSDonorEmailController.cls
+++ b/src/classes/frWSDonorEmailController.cls
@@ -1,0 +1,58 @@
+/*
+ *
+ *  Copyright (c) 2016, Funraise Inc
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. All advertising materials mentioning features or use of this software
+ *     must display the following acknowledgement:
+ *     This product includes software developed by the <organization>.
+ *  4. Neither the name of the <organization> nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ * PURPOSE:
+ *
+ *
+ *
+ * CREATED: 2016 Funraise Inc - https://funraise.io
+ * AUTHOR: Jason M. Swenski
+ */
+@RestResource(urlMapping='/v1/donoremail')
+global with sharing class frWSDonorEmailController {
+
+    @HttpPost
+    global static void syncEntity() {
+        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
+        frDonorEmails donorEmails = frDonorEmails.create(request);
+
+        Map<String,Object> resp = new Map<String,Object>();
+        if (donorEmails == null) {
+            resp.put('id', -1);
+        } else {
+        	resp.put('id', donorEmails.getContactId());
+        }
+
+        RestContext.response.addHeader('Content-Type', 'application/json');
+        RestContext.response.responseBody = Blob.valueOf(JSON.serialize(resp));
+    }
+}

--- a/src/classes/frWSDonorEmailController.cls
+++ b/src/classes/frWSDonorEmailController.cls
@@ -37,7 +37,7 @@
  * CREATED: 2016 Funraise Inc - https://funraise.io
  * AUTHOR: Jason M. Swenski
  */
-@RestResource(urlMapping='/v1/donoremail')
+@RestResource(urlMapping='/v1/email')
 global with sharing class frWSDonorEmailController {
 
     @HttpPost

--- a/src/classes/frWSDonorEmailController.cls
+++ b/src/classes/frWSDonorEmailController.cls
@@ -43,14 +43,10 @@ global with sharing class frWSDonorEmailController {
     @HttpPost
     global static void syncEntity() {
         Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frDonorEmails donorEmails = frDonorEmails.create(request);
+        String contactId = frDonorEmails.create(request);
 
         Map<String,Object> resp = new Map<String,Object>();
-        if (donorEmails == null) {
-            resp.put('id', -1);
-        } else {
-        	resp.put('id', donorEmails.getContactId());
-        }
+        resp.put('id', contactId);
 
         RestContext.response.addHeader('Content-Type', 'application/json');
         RestContext.response.responseBody = Blob.valueOf(JSON.serialize(resp));

--- a/src/classes/frWSDonorEmailControllerTest.cls
+++ b/src/classes/frWSDonorEmailControllerTest.cls
@@ -1,0 +1,154 @@
+/*
+ *
+ *  Copyright (c) 2016, Funraise Inc
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. All advertising materials mentioning features or use of this software
+ *     must display the following acknowledgement:
+ *     This product includes software developed by the <organization>.
+ *  4. Neither the name of the <organization> nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ * PURPOSE:
+ *
+ *
+ *
+ * CREATED: 2018 Funraise Inc - https://funraise.io
+ * AUTHOR: Jordan Speer
+ */
+@isTest
+public class frWSDonorEmailControllerTest {
+    static testMethod void syncEntity_test() {
+        Contact testContact = new Contact(
+            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
+            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ',
+            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = '856'
+        );
+        insert testContact;
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donoremail';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(getTestPayload());
+        RestContext.request = req;
+        RestContext.response = res;
+
+        Test.startTest();
+
+        frWSDonorEmailController.syncEntity();
+
+        Test.stopTest();
+
+
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+
+
+        Id contactId = response.id;
+        System.assert(String.isNotBlank(contactId),
+            'There was not an contact Id in the response as expected');
+        Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
+        System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
+        Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :contactId];
+        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
+    }
+
+    static testMethod void syncEntity_multipleEmails() {
+        Contact testContact = new Contact(
+            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
+            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ',
+            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = '856'
+        );
+        insert testContact;
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donoremail';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(getMultipleTestPayload());
+        RestContext.request = req;
+        RestContext.response = res;
+
+        Test.startTest();
+
+        frWSDonorEmailController.syncEntity();
+
+        Test.stopTest();
+
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+
+        Id contactId = response.id;
+        System.assert(String.isNotBlank(contactId),
+            'There was not an contact Id in the response as expected');
+        Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
+        System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
+        Integer eventCount = [SELECT COUNT() FROM Event WHERE WhoId = :contactId];
+        System.assertEquals(2, eventCount, 'The funraise email count was not correct');
+    }
+
+    private static void createMapping(String frField, String sfField) {
+        insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonor.TYPE);
+    }
+
+    public class MockResponse {
+        String id;
+        Boolean success;
+    }
+
+    private static String getTestPayload() {
+        return '{'+
+            '"id":856,'+
+            '"emails": {'+
+            	'"db92570b-766b-46b9-8b7a-a0c7efa92053": {'+
+                    '"emailId": 4,'+
+                    '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
+                    '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
+                    '"statusCode": 202,'+
+                    '"sentDate": ' + 1536184380L + ','+
+                    '"subject": "Hello there"}'+
+            	'}'+
+        	'}';
+    }
+        private static String getMultipleTestPayload() {
+            return '{'+
+                '"id":856,'+
+                '"emails": {'+
+                	'"db92570b-766b-46b9-8b7a-a0c7efa92053": {'+
+                        '"emailId": 4,'+
+                        '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
+                        '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
+                        '"statusCode": 202,'+
+                    	'"sentDate": ' + 1536184380L + ','+
+                        '"subject": "Hello there"},'+
+                	'"ab6c2dc6-3156-484c-b8f7-c203070259b9": {'+
+                        '"emailId": 2,'+
+                        '"messageId": "ab6c2dc6-3156-484c-b8f7-c203070259b9",'+
+                        '"correlationId": "zrtusKL1QWK_yddRylVQ0A",'+
+                        '"statusCode": 202,'+
+                    	'"sentDate": ' + 1536184380L + ','+
+                        '"subject": "Hello again"}'+
+                	'}'+
+            '}';
+        }
+}

--- a/src/classes/frWSDonorEmailControllerTest.cls
+++ b/src/classes/frWSDonorEmailControllerTest.cls
@@ -74,43 +74,6 @@ public class frWSDonorEmailControllerTest {
         System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
     }
 
-    static testMethod void syncEntity_multipleEmails() {
-        Contact testContact = new Contact(
-            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
-            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ',
-            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = '856'
-        );
-        insert testContact;
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donoremail';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getMultipleTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-
-        Test.startTest();
-
-        frWSDonorEmailController.syncEntity();
-
-        Test.stopTest();
-
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId),
-            'There was not an contact Id in the response as expected');
-        Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
-        System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
-        Integer eventCount = [SELECT COUNT() FROM Event WHERE WhoId = :contactId];
-        System.assertEquals(2, eventCount, 'The funraise email count was not correct');
-    }
-
-    private static void createMapping(String frField, String sfField) {
-        insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonor.TYPE);
-    }
-
     public class MockResponse {
         String id;
         Boolean success;
@@ -119,36 +82,23 @@ public class frWSDonorEmailControllerTest {
     private static String getTestPayload() {
         return '{'+
             '"id":856,'+
-            '"emails": {'+
-            	'"db92570b-766b-46b9-8b7a-a0c7efa92053": {'+
-                    '"emailId": 4,'+
-                    '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
-                    '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
-                    '"statusCode": 202,'+
-                    '"sentDate": ' + 1536184380L + ','+
-                    '"subject": "Hello there"}'+
-            	'}'+
+            '"emailId": 4,'+
+            '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
+            '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
+            '"statusCode": 202,'+
+            '"sentDate": ' + 1536184380L + ','+
+            '"subject": "Hello there"'+
         	'}';
     }
         private static String getMultipleTestPayload() {
             return '{'+
                 '"id":856,'+
-                '"emails": {'+
-                	'"db92570b-766b-46b9-8b7a-a0c7efa92053": {'+
-                        '"emailId": 4,'+
-                        '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
-                        '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
-                        '"statusCode": 202,'+
-                    	'"sentDate": ' + 1536184380L + ','+
-                        '"subject": "Hello there"},'+
-                	'"ab6c2dc6-3156-484c-b8f7-c203070259b9": {'+
-                        '"emailId": 2,'+
-                        '"messageId": "ab6c2dc6-3156-484c-b8f7-c203070259b9",'+
-                        '"correlationId": "zrtusKL1QWK_yddRylVQ0A",'+
-                        '"statusCode": 202,'+
-                    	'"sentDate": ' + 1536184380L + ','+
-                        '"subject": "Hello again"}'+
-                	'}'+
+                '"emailId": 4,'+
+                '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
+                '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
+                '"statusCode": 202,'+
+                '"sentDate": ' + 1536184380L + ','+
+                '"subject": "Hello there"'+
             '}';
         }
 }

--- a/src/classes/frWSDonorEmailControllerTest.cls
+++ b/src/classes/frWSDonorEmailControllerTest.cls
@@ -70,8 +70,8 @@ public class frWSDonorEmailControllerTest {
             'There was not an contact Id in the response as expected');
         Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
         System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
-        Event newEvent = [SELECT fr_Email_ID__c FROM Event WHERE WhoId = :contactId];
-        System.assertEquals('4', newEvent.fr_Email_ID__C, 'The funraise email id was not correct');
+        EmailMessage newEmail = [SELECT fromAddress FROM EmailMessage WHERE fr_Email_ID__c = '4'];
+        System.assertEquals('email@funraise.io', newEmail.fromAddress, 'The funraise email address was not correct');
     }
 
     public class MockResponse {
@@ -85,20 +85,12 @@ public class frWSDonorEmailControllerTest {
             '"emailId": 4,'+
             '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
             '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
+            '"fromAddress": "email@funraise.io",' +
+            '"fromName": "John Smith",' +
+            '"toAddress": "testEmail@google.com",' +
             '"statusCode": 202,'+
             '"sentDate": ' + 1536184380L + ','+
             '"subject": "Hello there"'+
         	'}';
     }
-        private static String getMultipleTestPayload() {
-            return '{'+
-                '"id":856,'+
-                '"emailId": 4,'+
-                '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
-                '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
-                '"statusCode": 202,'+
-                '"sentDate": ' + 1536184380L + ','+
-                '"subject": "Hello there"'+
-            '}';
-        }
 }

--- a/src/objects/EmailMessage.object
+++ b/src/objects/EmailMessage.object
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>fr_Email_ID__c</fullName>
+        <description>Email ID from funraise</description>
+        <externalId>true</externalId>
+        <label>Funraise Email ID</label>
+        <length>255</length>
+        <required>true</required>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+</CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -3,6 +3,8 @@
     <types>
         <members>frDonation</members>
         <members>frDonor</members>
+        <members>frDonorEmails</members>
+        <members>frDonorEmailsTest</members>
         <members>frDonorTest</members>
         <members>frModel</members>
         <members>frSchemaUtil</members>
@@ -24,6 +26,7 @@
     </types>
     <types>
         <members>Contact.fr_ID__c</members>
+        <members>EmailMessage.fr_Email_ID__c</members>
         <members>Opportunity.fr_Donor__c</members>
         <members>Opportunity.fr_ID__c</members>
         <name>CustomField</name>
@@ -42,5 +45,5 @@
         <members>*</members>
         <name>CustomMetadata</name>
     </types>
-    <version>36.0</version>
+    <version>43.0</version>
 </Package>


### PR DESCRIPTION
Emails sent to /donoremail endpoint is added to a contact as previous 
activity history.
Added tests for DonorEmailController and DonorEmail.
If an email is sent that doesn't associate with a contact no emails are 
added.

Resolves: FUN-4744