### PR TITLE
Sync and Map Donor Tags To Salesforce (SF)

### DIFF
--- a/src/classes/frDonor.cls
+++ b/src/classes/frDonor.cls
@@ -138,6 +138,27 @@ public class frDonor extends frModel {
         return donor;
     }
 
+    public void addTags(List<Object> tags) {
+        if(tags == null || tags.isEmpty()){
+            return;
+        }
+
+        Contact c = getContact();
+
+        List<ContactTag> contactTags = new List<ContactTag>();
+
+        for(Object tag : tags){
+            String name = String.valueOf(tag);
+            ContactTag contactTag = new ContactTag();
+            contactTag.ItemId = c.Id;
+            contactTag.Name = mapTag(name);
+            contactTag.Type = 'Personal';
+            contactTags.add(contactTag);
+        }
+
+        Database.upsert(contactTags);
+    }
+
     public Boolean save() {
         Boolean isSuccess = false;
         try {
@@ -163,6 +184,7 @@ public class frDonor extends frModel {
     }
 
     public void setContactId(String contactId) {
+        System.debug('Setting contact id: ' + contactId);
         if(this.c == null) {
             this.c = new Contact(Id = contactId);
         }

--- a/src/classes/frModel.cls
+++ b/src/classes/frModel.cls
@@ -1,4 +1,16 @@
 public abstract class frModel {
+    public static String TAG_TYPE = 'Tag';
+
+    public static List<frMapping__c> tagMappings {
+        get {
+            if(tagMappings == null) {
+                tagMappings = [SELECT fr_Name__c, sf_Name__c, Type__c FROM frMapping__c WHERE Type__c = :TAG_TYPE ORDER BY CreatedDate];
+            }
+            return tagMappings;
+        }
+        set;
+    }
+
 	protected abstract SObject getObject();
     public abstract List<frMapping__c> getMappings();
 
@@ -84,11 +96,11 @@ public abstract class frModel {
         }
     }
 
-    protected void handleException(Exception ex) {
+    public static void handleException(Exception ex) {
         insert new Error__c(Error__c = ex.getMessage());
     }
 
-    
+
     public static void flushLogs() {
         if([SELECT COUNT() FROM Error__c] > 100) {
             deleteLogs();
@@ -100,4 +112,13 @@ public abstract class frModel {
         delete [SELECT Id FROM Error__c ORDER BY CreatedDate DESC LIMIT 10000 OFFSET 100];
     }
 
+    public static String mapTag(String frTagName){
+        for(frMapping__c m : tagMappings){
+            if(frTagName == m.fr_Name__c){
+                return m.sf_Name__c;
+            }
+        }
+
+        return frTagName;
+    }
 }

--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -11,7 +11,13 @@ public with sharing class frSetupController {
 		}
 		private set;
 	}
-    
+	public static String TAG_TYPE {
+		get {
+			return frModel.TAG_TYPE;
+		}
+		private set;
+	}
+
     public static Set<String> RESTRICTED_DONOR_FIELDS {
         get {
             if(RESTRICTED_DONOR_FIELDS == null) {
@@ -23,12 +29,12 @@ public with sharing class frSetupController {
         }
         private set;
     }
-    
+
     public static Set<String> RESTRICTED_DONATION_FIELDS {
         get {
             if(RESTRICTED_DONATION_FIELDS == null) {
                 RESTRICTED_DONATION_FIELDS = new Set<String>{
-                    'funraise__fr_ID__c', 
+                    'funraise__fr_ID__c',
                     'funraise__fr_Donor__c'
                 };
             }
@@ -44,7 +50,11 @@ public with sharing class frSetupController {
 	public List<SelectOption> donorSFOptions {get; set;}
 	public List<SelectOption> donorFROptions {get; set;}
 	public List<frMapping__c> donorMappings {get; set;}
-	
+
+	public List<SelectOption> tagSFOptions {get; set;}
+	public List<SelectOption> tagFROptions {get; set;}
+	public List<frMapping__c> tagMappings {get; set;}
+
 	public frSetupController() {
 		SelectOption noneOption = new SelectOption('', '--None--');
 		donationSFOptions = new List<SelectOption>();
@@ -55,6 +65,10 @@ public with sharing class frSetupController {
 		donorSFOptions.add(noneOption);
 		donorFROptions = new List<SelectOption>();
 		donorFROptions.add(noneOption);
+		tagSFOptions = new List<SelectOption>();
+		tagSFOptions.add(noneOption);
+		tagFROptions = new List<SelectOption>();
+		tagFROptions.add(noneOption);
 
 		Map<String, Schema.SObjectField> oppFields = Opportunity.sObjectType.getDescribe().fields.getMap();
 		for(String fieldName : oppFields.keySet()) {
@@ -83,8 +97,13 @@ public with sharing class frSetupController {
 			donorFROptions.add(new SelectOption(field.DeveloperName, field.MasterLabel));
 		}
 
+        for(ContactTag sfTag : [SELECT Name FROM ContactTag]){
+            tagSFOptions.add(new SelectOption(sfTag.Name, sfTag.Name));
+        }
+
 		donationMappings = frDonation.mappings;
 		donorMappings = frDonor.mappings;
+        tagMappings = frModel.tagMappings;
 	}
 
 	public void addMapping() {
@@ -92,11 +111,13 @@ public with sharing class frSetupController {
 		if(String.isBlank(type)) {
 			return;
 		}
-		if(DONATION_TYPE.equals(type)) {			
+		if(DONATION_TYPE.equals(type)) {
 			donationMappings.add(new frMapping__c(Type__c = DONATION_TYPE));
-		} else {
+		} else if(DONOR_TYPE.equals(type)){
 			donorMappings.add(new frMapping__c(Type__c = DONOR_TYPE));
-		}
+        } else {
+            tagMappings.add(new frMapping__c(Type__c = TAG_TYPE));
+        }
 	}
 
 	public void removeMapping() {
@@ -110,7 +131,15 @@ public with sharing class frSetupController {
 			return;
 		}
 
-		List<frMapping__c> mappings = DONATION_TYPE.equals(type) ? donationMappings : donorMappings;
+		List<frMapping__c> mappings;
+        if(DONATION_TYPE.equals(type)){
+            mappings = donationMappings;
+        } else if(DONOR_TYPE.equals(type)){
+            mappings = donorMappings;
+        } else {
+            mappings = tagMappings;
+        }
+
 		for(Integer i = 0; i < mappings.size(); i++) {
 			frMapping__c mapping = mappings.get(i);
 			if(recordId.equals(mapping.id)) {
@@ -123,13 +152,30 @@ public with sharing class frSetupController {
 	}
 
 	public void save() {
+        if (!Schema.sObjectType.frMapping__c.fields.Name.isUpdateable() ||
+           !Schema.sObjectType.frMapping__c.fields.Name.isCreateable()) {
+            return;
+        }
+
 		Integer customSettingNameLength = frMapping__c.Name.getDescribe().getLength();
 		List<frMapping__c> upsertList = new List<frMapping__c>();
 		List<frMapping__c> allMappings = new List<frMapping__c>(donationMappings);
 		allMappings.addAll(donorMappings);
+        allMappings.addAll(tagMappings);
 		for(frMapping__c mapping : allMappings) {
 			if(String.isNotBlank(mapping.sf_Name__c)) {
-				mapping.Name = (mapping.Type__c == DONATION_TYPE ? 'o.' : 'c.') + mapping.sf_Name__c;
+                String prefix = '';
+
+                if(DONATION_TYPE.equals(mapping.Type__c)){
+                    prefix = 'o.';
+                } else if(DONOR_TYPE.equals(mapping.Type__c)){
+                    prefix = 'c.';
+                } else if(TAG_TYPE.equals(mapping.Type__c)){
+                    prefix = 't.';
+                }
+
+                mapping.Name = prefix + mapping.sf_Name__c;
+
 				if(mapping.Name.length() > customSettingNameLength) {
 					mapping.Name = mapping.Name.subString(0, customSettingNameLength);
 				}
@@ -164,20 +210,22 @@ public with sharing class frSetupController {
 	}
 
 	private void addError(String message) {
-		ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, message));	
+		ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, message));
 	}
 
 	public void defaults() {
 		if(!checkCD()) {
 			return;
 		}
-		delete [SELECT Id FROM frMapping__c];
+		delete [SELECT Id FROM frMapping__c LIMIT 10000];
 		List<frMapping__c> defaults = getDonorDefaults();
 		defaults.addAll(getDonationDefaults());
+		defaults.addAll(getTagDefaults());
 		insert defaults;
 		addConfirm('All Defaults Applied');
 		donationMappings = frDonation.mappings;
 		donorMappings = frDonor.mappings;
+		tagMappings = frModel.tagMappings;
 	}
 
 	public void donorDefaults() {
@@ -202,6 +250,17 @@ public with sharing class frSetupController {
 		donationMappings = frDonation.mappings;
 	}
 
+	public void tagDefaults() {
+		if(!checkCD()) {
+			return;
+		}
+		delete [SELECT Id FROM frMapping__c WHERE Type__c = :TAG_TYPE];
+		List<frMapping__c> defaults = getTagDefaults();
+		insert defaults;
+		addConfirm('Tag Defaults Applied');
+		tagMappings = frModel.tagMappings;
+	}
+
 	private Boolean checkCD() {
 		Schema.DescribeSObjectResult mappingDescribe = frMapping__c.sObjectType.getDescribe();
 		if(mappingDescribe.isCreateable() && mappingDescribe.isDeletable()) {
@@ -222,7 +281,8 @@ public with sharing class frSetupController {
 			new frMapping__c(Name = 'City Default', fr_Name__c = 'city', sf_Name__c = 'mailingcity', Type__c = DONOR_TYPE),
 			new frMapping__c(Name = 'State Default', fr_Name__c = 'state', sf_Name__c = 'mailingstate', Type__c = DONOR_TYPE),
 			new frMapping__c(Name = 'Postal Code Default', fr_Name__c = 'postalCode', sf_Name__c = 'mailingpostalcode', Type__c = DONOR_TYPE),
-			new frMapping__c(Name = 'Country Default', fr_Name__c = 'country', sf_Name__c = 'mailingcountry', Type__c = DONOR_TYPE)
+			new frMapping__c(Name = 'Country Default', fr_Name__c = 'country', sf_Name__c = 'mailingcountry', Type__c = DONOR_TYPE),
+			new frMapping__c(Name = 'Fundraiser Default', fr_Name__c = 'fundraiser', sf_Name__c = 'funraise__is_fundraiser__c', Type__c = DONOR_TYPE)
 		};
 	}
 
@@ -235,6 +295,11 @@ public with sharing class frSetupController {
 			new frMapping__c(Name = 'Stage Default', Is_Constant__c = true, Constant_Value__c = 'Closed Won', sf_Name__c = 'stagename', Type__c = DONATION_TYPE),
 			new frMapping__c(Name = 'Probability Default', Is_Constant__c = true, Constant_Value__c = '100', sf_Name__c = 'probability', Type__c = DONATION_TYPE)
 		};
+	}
+
+	@testVisible
+	private static List<frMapping__c> getTagDefaults() {
+		return new List<frMapping__c>{};
 	}
 
 }

--- a/src/classes/frWSDonorController.cls
+++ b/src/classes/frWSDonorController.cls
@@ -47,6 +47,8 @@ global with sharing class frWSDonorController {
         frDonor donor = frDonor.create(request);
         Boolean isSuccess = donor.save();
 
+        donor.addTags((List<Object>)request.get('tags'));
+
         Map<String,Object> resp = new Map<String,Object>();
         resp.put('id', donor.getContactId());
         resp.put('success', isSuccess);

--- a/src/classes/frWSDonorControllerTest.cls
+++ b/src/classes/frWSDonorControllerTest.cls
@@ -49,27 +49,27 @@ public class frWSDonorControllerTest {
         RestContext.request = req;
         RestContext.response = res;
 
-        createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
-        createMapping('email', 'email');
-        createMapping('address1', 'MailingStreet');
-        createMapping('city', 'MailingCity');
-        createMapping('state', 'MailingState');
-        createMapping('postalCode', 'MailingPostalCode');
-        createMapping('country', 'MailingCountry');
-        createMapping('donor_cretime', 'BirthDate');
+        createMapping('firstName', 'FirstName', frDonor.TYPE);
+        createMapping('lastName', 'LastName', frDonor.TYPE);
+        createMapping('email', 'email', frDonor.TYPE);
+        createMapping('address1', 'MailingStreet', frDonor.TYPE);
+        createMapping('city', 'MailingCity', frDonor.TYPE);
+        createMapping('state', 'MailingState', frDonor.TYPE);
+        createMapping('postalCode', 'MailingPostalCode', frDonor.TYPE);
+        createMapping('country', 'MailingCountry', frDonor.TYPE);
+        createMapping('donor_cretime', 'BirthDate', frDonor.TYPE);
         Test.startTest();
 
         frWSDonorController.syncEntity();
 
         Test.stopTest();
-        
+
 
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
 
-        
+
         Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
+        System.assert(String.isNotBlank(contactId),
             'There was not an contact Id in the response as expected');
         Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
         System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
@@ -91,26 +91,26 @@ public class frWSDonorControllerTest {
         RestContext.request = req;
         RestContext.response = res;
 
-        createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
-        createMapping('email', 'email');
-        createMapping('address1', 'MailingStreet');
-        createMapping('city', 'MailingCity');
-        createMapping('state', 'MailingState');
-        createMapping('postalCode', 'MailingPostalCode');
-        createMapping('country', 'MailingCountry');
+        createMapping('firstName', 'FirstName', frDonor.TYPE);
+        createMapping('lastName', 'LastName', frDonor.TYPE);
+        createMapping('email', 'email', frDonor.TYPE);
+        createMapping('address1', 'MailingStreet', frDonor.TYPE);
+        createMapping('city', 'MailingCity', frDonor.TYPE);
+        createMapping('state', 'MailingState', frDonor.TYPE);
+        createMapping('postalCode', 'MailingPostalCode', frDonor.TYPE);
+        createMapping('country', 'MailingCountry', frDonor.TYPE);
         Test.startTest();
 
         frWSDonorController.syncEntity();
 
         Test.stopTest();
-        
+
 
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
 
-        
+
         Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
+        System.assert(String.isNotBlank(contactId),
             'There was not an contact Id in the response as expected');
         System.assertEquals(existing.Id, contactId, 'The existing contact should have been used');
         Contact newContact = [SELECT Id, fr_ID__c, Email FROM Contact WHERE Id = :contactId];
@@ -134,26 +134,26 @@ public class frWSDonorControllerTest {
         RestContext.request = req;
         RestContext.response = res;
 
-        createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
-        createMapping('email', 'email');
-        createMapping('address1', 'MailingStreet');
-        createMapping('city', 'MailingCity');
-        createMapping('state', 'MailingState');
-        createMapping('postalCode', 'MailingPostalCode');
-        createMapping('country', 'MailingCountry');
+        createMapping('firstName', 'FirstName', frDonor.TYPE);
+        createMapping('lastName', 'LastName', frDonor.TYPE);
+        createMapping('email', 'email', frDonor.TYPE);
+        createMapping('address1', 'MailingStreet', frDonor.TYPE);
+        createMapping('city', 'MailingCity', frDonor.TYPE);
+        createMapping('state', 'MailingState', frDonor.TYPE);
+        createMapping('postalCode', 'MailingPostalCode', frDonor.TYPE);
+        createMapping('country', 'MailingCountry', frDonor.TYPE);
         Test.startTest();
 
         frWSDonorController.syncEntity();
 
         Test.stopTest();
-        
+
 
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
 
-        
+
         Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
+        System.assert(String.isNotBlank(contactId),
             'There was not an contact Id in the response as expected');
         System.assertEquals(existing.Id, contactId, 'The existing contact should have been used');
         Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
@@ -185,26 +185,26 @@ public class frWSDonorControllerTest {
         RestContext.request = req;
         RestContext.response = res;
 
-        createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
-        createMapping('email', 'email');
-        createMapping('address1', 'MailingStreet');
-        createMapping('city', 'MailingCity');
-        createMapping('state', 'MailingState');
-        createMapping('postalCode', 'MailingPostalCode');
-        createMapping('country', 'MailingCountry');
+        createMapping('firstName', 'FirstName', frDonor.TYPE);
+        createMapping('lastName', 'LastName', frDonor.TYPE);
+        createMapping('email', 'email', frDonor.TYPE);
+        createMapping('address1', 'MailingStreet', frDonor.TYPE);
+        createMapping('city', 'MailingCity', frDonor.TYPE);
+        createMapping('state', 'MailingState', frDonor.TYPE);
+        createMapping('postalCode', 'MailingPostalCode', frDonor.TYPE);
+        createMapping('country', 'MailingCountry', frDonor.TYPE);
         Test.startTest();
 
         frWSDonorController.syncEntity();
 
         Test.stopTest();
-        
+
 
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
 
-        
+
         Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
+        System.assert(String.isNotBlank(contactId),
             'There was not an contact Id in the response as expected');
         System.assertEquals(existing.Id, contactId, 'The existing contact should have been used');
         Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
@@ -223,25 +223,25 @@ public class frWSDonorControllerTest {
         RestContext.request = req;
         RestContext.response = res;
 
-        createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
-        createMapping('email', 'email');
-        createMapping('address1', 'MailingStreet');
-        createMapping('city', 'MailingCity');
-        createMapping('state', 'MailingState');
-        createMapping('postalCode', 'MailingPostalCode');
-        createMapping('country', 'MailingCountry');
+        createMapping('firstName', 'FirstName', frDonor.TYPE);
+        createMapping('lastName', 'LastName', frDonor.TYPE);
+        createMapping('email', 'email', frDonor.TYPE);
+        createMapping('address1', 'MailingStreet', frDonor.TYPE);
+        createMapping('city', 'MailingCity', frDonor.TYPE);
+        createMapping('state', 'MailingState', frDonor.TYPE);
+        createMapping('postalCode', 'MailingPostalCode', frDonor.TYPE);
+        createMapping('country', 'MailingCountry', frDonor.TYPE);
 
         //bad mapping for date
-        createMapping('institutionCategory', 'BirthDate');
+        createMapping('institutionCategory', 'BirthDate', frDonor.TYPE);
         //bad mapping for datetime
-        createMapping('p2gScore', 'LastCURequestDate');
+        createMapping('p2gScore', 'LastCURequestDate', frDonor.TYPE);
         Test.startTest();
 
         frWSDonorController.syncEntity();
 
         Test.stopTest();
-        
+
         List<Error__c> errors = [SELECT Error__c FROM Error__c];
         String errorsStr = '';
         for(Error__c error : errors) {
@@ -253,15 +253,57 @@ public class frWSDonorControllerTest {
 
         //but even with bad field mappings the record should still come over correctly
         Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
+        System.assert(String.isNotBlank(contactId),
             'There was not an contact Id in the response as expected');
         Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
 
         System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
     }
 
-    private static void createMapping(String frField, String sfField) {
-        insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonor.TYPE);
+    static testMethod void syncEntity_addTags() {
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(getTestPayload());
+        RestContext.request = req;
+        RestContext.response = res;
+
+        createMapping('firstName', 'FirstName', frDonor.TYPE);
+        createMapping('lastName', 'LastName', frDonor.TYPE);
+        createMapping('email', 'email', frDonor.TYPE);
+        createMapping('address1', 'MailingStreet', frDonor.TYPE);
+        createMapping('city', 'MailingCity', frDonor.TYPE);
+        createMapping('state', 'MailingState', frDonor.TYPE);
+        createMapping('postalCode', 'MailingPostalCode', frDonor.TYPE);
+        createMapping('country', 'MailingCountry', frDonor.TYPE);
+        createMapping('donor_cretime', 'BirthDate', frDonor.TYPE);
+
+        createMapping('Feeding Poor', 'Hunger Force', frModel.TAG_TYPE);
+        createMapping('Free Housing', 'House Power', frModel.TAG_TYPE);
+
+        Test.startTest();
+
+        frWSDonorController.syncEntity();
+
+        Test.stopTest();
+
+
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+
+
+        Id contactId = response.id;
+
+        List<ContactTag> tags = [SELECT Name FROM ContactTag WHERE ItemId = :contactId];
+
+        System.assertEquals('Hunger Force', tags.get(0).Name, 'Tag was not mapped');
+        System.assertEquals('House Power', tags.get(1).Name, 'Tag was not mapped');
+        System.assertEquals('School Books', tags.get(2).Name, 'Un-mapped Tag was not passed through');
+    }
+
+    private static void createMapping(String frField, String sfField, String mappingType) {
+        insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = mappingType);
     }
 
     public class MockResponse {
@@ -314,6 +356,7 @@ public class frWSDonorControllerTest {
                 '"fundraiserDonationAmount":null,'+
                 '"fundraiserDonationCount":null,'+
                 '"fundraiser":false,'+
+                '"tags":["Feeding Poor", "Free Housing", "School Books"],'+
                 '"donor_cretime":1487801043597'+
         '}';
     }

--- a/src/classes/frWSTaskController.cls
+++ b/src/classes/frWSTaskController.cls
@@ -114,6 +114,11 @@ global with sharing class frWSTaskController {
 		Map<String,Object> resp = new Map<String,Object>();
         resp.put('success', success);
         resp.put('message', message);
+
+        if(!success){
+            insert new Error__c(Error__c = message);
+        }
+
         RestContext.response.responseBody = Blob.valueOf(JSON.serialize(resp));
     }
 }

--- a/src/classes/frWSTaskController.cls
+++ b/src/classes/frWSTaskController.cls
@@ -83,9 +83,14 @@ global with sharing class frWSTaskController {
 
             sfTask.put('fr_Task_ID__c', frTaskId);
 
-            String description = (String)frTask.get('description');
-            sfTask.Subject = description;
-            sfTask.Description = description;
+            if(frTask.containsKey('actionRequired')){
+                String actionRequired = (String)frTask.get('actionRequired');
+                if(actionRequired.trim().length() > 0){
+            		sfTask.Subject = actionRequired;
+                }
+            }
+
+            sfTask.Description = (String)frTask.get('description');
             sfTask.Priority = 'Normal';
             sfTask.ActivityDate = DateTime.newInstance((Long)frTask.get('createdDate')).dateGMT();
         } else {
@@ -99,12 +104,6 @@ global with sharing class frWSTaskController {
             sfTask.ActivityDate = DateTime.newInstance((Long)frTask.get('completedDate')).dateGMT();
         } else if(frStatus == 'Pending'){
             sfTask.Status = 'Waiting on someone else';
-            if(frTask.containsKey('assignedToName')){
-                String assignedToName = (String)frTask.get('assignedToName');
-                if(assignedToName.trim().length() > 0){
-            		sfTask.Status = 'Waiting on ' + frTask.get('assignedToName');
-                }
-            }
         } else if(frStatus == 'Canceled'){
             sfTask.Status = 'Not Started';
         }

--- a/src/classes/frWSTaskController.cls
+++ b/src/classes/frWSTaskController.cls
@@ -57,15 +57,7 @@ global with sharing class frWSTaskController {
             return;
         }
 
-        String donationId = String.valueOf(frTask.get('donationId'));
-        List<Opportunity> opportunities = (List<Opportunity>)Database.query('select Id, fr_ID__c from Opportunity where fr_ID__c = :donationId');
-        if(opportunities.isEmpty()){
-            setResponse('Opportunity not found for donationId:  ' + donationId, false);
-            return;
-        }
-
         Contact contact = contacts.get(0);
-        Opportunity opportunity = opportunities.get(0);
 
         List<Task> existingSfTasks = (List<Task>)Database.query('select Id, fr_Task_ID__c from Task where fr_Task_ID__c = :frTaskId');
 
@@ -74,17 +66,28 @@ global with sharing class frWSTaskController {
         if(existingSfTasks.isEmpty()){
             sfTask = new Task();
             sfTask.WhoId = contact.Id;
-            sfTask.WhatId = opportunity.Id;
+
+            String donationId = '';
+        	if(frTask.containsKey('donationId') && frTask.get('donationId') != null){
+            	donationId = String.valueOf(frTask.get('donationId'));
+        	}
+
+        	List<Opportunity> opportunities = new List<Opportunity>();
+        	if(donationId.length() > 0){
+        		opportunities = (List<Opportunity>)Database.query('select Id, fr_ID__c from Opportunity where fr_ID__c = :donationId');
+        	}
+
+            if(!opportunities.isEmpty()){
+            	sfTask.WhatId = opportunities.get(0).Id;
+            }
+
             sfTask.put('fr_Task_ID__c', frTaskId);
-            sfTask.Description = (String)frTask.get('description');
+
+            String description = (String)frTask.get('description');
+            sfTask.Subject = description;
+            sfTask.Description = description;
             sfTask.Priority = 'Normal';
             sfTask.ActivityDate = DateTime.newInstance((Long)frTask.get('createdDate')).dateGMT();
-            if(frTask.containsKey('assignedToName')){
-                String assignedToName = (String)frTask.get('assignedToName');
-                if(assignedToName.trim().length() > 0){
-            		sfTask.Status = 'Waiting on ' + frTask.get('assignedToName');
-                }
-            }
         } else {
             sfTask = existingSfTasks.get(0);
         }
@@ -96,6 +99,12 @@ global with sharing class frWSTaskController {
             sfTask.ActivityDate = DateTime.newInstance((Long)frTask.get('completedDate')).dateGMT();
         } else if(frStatus == 'Pending'){
             sfTask.Status = 'Waiting on someone else';
+            if(frTask.containsKey('assignedToName')){
+                String assignedToName = (String)frTask.get('assignedToName');
+                if(assignedToName.trim().length() > 0){
+            		sfTask.Status = 'Waiting on ' + frTask.get('assignedToName');
+                }
+            }
         } else if(frStatus == 'Canceled'){
             sfTask.Status = 'Not Started';
         }

--- a/src/classes/frWSTaskController.cls
+++ b/src/classes/frWSTaskController.cls
@@ -1,0 +1,114 @@
+/*
+*
+*  Copyright (c) 2016, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:
+*
+*
+*
+* CREATED: 9-18-2018 Funraise Inc - https://funraise.io
+* AUTHOR: Mark D. Dufresne
+*/
+
+@RestResource(urlMapping='/v1/task')
+global with sharing class frWSTaskController {
+    
+    @HttpPost
+    global static void syncEntity() {
+        Map<String, Object> frTask = (Map<String, Object>)JSON.deserializeUntyped(
+            RestContext.request.requestBody.toString()
+        );
+        
+        RestContext.response.addHeader('Content-Type', 'application/json');
+        
+        String frTaskId = String.valueOf(frTask.get('id'));
+        String donorId = String.valueOf(frTask.get('donorId'));
+        List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c from Contact where fr_ID__c = :donorId');
+        if(contacts.isEmpty()){
+            setResponse('Contact not found for donorId:  ' + donorId, false);
+            return;
+        }
+        
+        String donationId = String.valueOf(frTask.get('donationId'));
+        List<Opportunity> opportunities = (List<Opportunity>)Database.query('select Id, fr_ID__c from Opportunity where fr_ID__c = :donationId');
+        if(opportunities.isEmpty()){
+            setResponse('Opportunity not found for donationId:  ' + donationId, false);
+            return;
+        }
+        
+        Contact contact = contacts.get(0);
+        Opportunity opportunity = opportunities.get(0);
+        
+        List<Task> existingSfTasks = (List<Task>)Database.query('select Id, fr_Task_ID__c from Task where fr_Task_ID__c = :frTaskId');
+        
+        Task sfTask;
+        
+        if(existingSfTasks.isEmpty()){
+            sfTask = new Task();
+            sfTask.WhoId = contact.Id;
+            sfTask.WhatId = opportunity.Id;
+            sfTask.put('fr_Task_ID__c', frTaskId);
+            sfTask.Description = (String)frTask.get('description');
+            sfTask.Priority = 'Normal';
+            sfTask.ActivityDate = DateTime.newInstance((Long)frTask.get('createdDate')).dateGMT();
+            sfTask.Status = 'Waiting on someone else';
+        } else {
+            sfTask = existingSfTasks.get(0);
+        }
+        
+        String frType = (String)frTask.get('type');
+        String frStatus = (String)frTask.get('status');
+        if(frStatus == 'Complete' || frType == 'Interaction'){
+            sfTask.Status = 'Completed';
+            sfTask.ActivityDate = DateTime.newInstance((Long)frTask.get('completedDate')).dateGMT();
+        } else if(frStatus == 'Pending'){
+            sfTask.Status = 'Waiting on someone else';
+        } else if(frStatus == 'Canceled'){
+            sfTask.Status = 'Not Started';
+        }
+        
+        try {
+            upsert sfTask Task.Fields.fr_Task_ID__c;
+        } catch (DMLException e) {
+            setResponse(e.getMessage(), false);
+            return;
+        }
+        
+        setResponse('', true);
+    }
+    
+    private static void setResponse(String message, Boolean success){
+		Map<String,Object> resp = new Map<String,Object>();
+        resp.put('success', success);
+        resp.put('message', message);
+        RestContext.response.responseBody = Blob.valueOf(JSON.serialize(resp));
+    }
+}

--- a/src/classes/frWSTaskController.cls
+++ b/src/classes/frWSTaskController.cls
@@ -40,15 +40,15 @@
 
 @RestResource(urlMapping='/v1/task')
 global with sharing class frWSTaskController {
-    
+
     @HttpPost
     global static void syncEntity() {
         Map<String, Object> frTask = (Map<String, Object>)JSON.deserializeUntyped(
             RestContext.request.requestBody.toString()
         );
-        
+
         RestContext.response.addHeader('Content-Type', 'application/json');
-        
+
         String frTaskId = String.valueOf(frTask.get('id'));
         String donorId = String.valueOf(frTask.get('donorId'));
         List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c from Contact where fr_ID__c = :donorId');
@@ -56,21 +56,21 @@ global with sharing class frWSTaskController {
             setResponse('Contact not found for donorId:  ' + donorId, false);
             return;
         }
-        
+
         String donationId = String.valueOf(frTask.get('donationId'));
         List<Opportunity> opportunities = (List<Opportunity>)Database.query('select Id, fr_ID__c from Opportunity where fr_ID__c = :donationId');
         if(opportunities.isEmpty()){
             setResponse('Opportunity not found for donationId:  ' + donationId, false);
             return;
         }
-        
+
         Contact contact = contacts.get(0);
         Opportunity opportunity = opportunities.get(0);
-        
+
         List<Task> existingSfTasks = (List<Task>)Database.query('select Id, fr_Task_ID__c from Task where fr_Task_ID__c = :frTaskId');
-        
+
         Task sfTask;
-        
+
         if(existingSfTasks.isEmpty()){
             sfTask = new Task();
             sfTask.WhoId = contact.Id;
@@ -79,11 +79,16 @@ global with sharing class frWSTaskController {
             sfTask.Description = (String)frTask.get('description');
             sfTask.Priority = 'Normal';
             sfTask.ActivityDate = DateTime.newInstance((Long)frTask.get('createdDate')).dateGMT();
-            sfTask.Status = 'Waiting on someone else';
+            if(frTask.containsKey('assignedToName')){
+                String assignedToName = (String)frTask.get('assignedToName');
+                if(assignedToName.trim().length() > 0){
+            		sfTask.Status = 'Waiting on ' + frTask.get('assignedToName');
+                }
+            }
         } else {
             sfTask = existingSfTasks.get(0);
         }
-        
+
         String frType = (String)frTask.get('type');
         String frStatus = (String)frTask.get('status');
         if(frStatus == 'Complete' || frType == 'Interaction'){
@@ -94,17 +99,17 @@ global with sharing class frWSTaskController {
         } else if(frStatus == 'Canceled'){
             sfTask.Status = 'Not Started';
         }
-        
+
         try {
             upsert sfTask Task.Fields.fr_Task_ID__c;
         } catch (DMLException e) {
             setResponse(e.getMessage(), false);
             return;
         }
-        
+
         setResponse('', true);
     }
-    
+
     private static void setResponse(String message, Boolean success){
 		Map<String,Object> resp = new Map<String,Object>();
         resp.put('success', success);

--- a/src/classes/frWSTaskControllerTest.cls
+++ b/src/classes/frWSTaskControllerTest.cls
@@ -1,0 +1,87 @@
+/*
+*
+*  Copyright (c) 2016, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by Funraise inc.
+*  4. Neither the name of Funraise inc nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:
+*
+*
+*
+* CREATED: 9-19-2018 Funraise Inc - https://funraise.io
+* AUTHOR: Mark Daniel Dufresne
+*/
+@isTest
+public class frWSTaskControllerTest {
+    static testMethod void syncEntity_test() {
+        insert new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'testExisting@example.com', fr_ID__c = '410');
+        insert new Opportunity(fr_ID__c = '67', StageName = 'Closed Won', Name = 'donation1', CloseDate = Date.today());
+        insert new Opportunity(fr_ID__c = '68', StageName = 'Closed Won', Name = 'donation2', CloseDate = Date.today());
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(getTestPayload());
+        RestContext.request = req;
+        RestContext.response = res;
+        
+        Test.startTest();
+        
+        frWSTaskController.syncEntity();
+        
+        Test.stopTest();
+        
+        Map<String, Object> response = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString()
+        );
+        
+        Boolean success = (Boolean)response.get('success');
+        System.assert(success, 'task update failed');
+        
+        String message = (String)response.get('message');
+        System.assertEquals('', message, 'error message on update');
+    }
+    
+    private static String getTestPayload() {
+        
+        return '{'+
+                '"id":856,'+
+                '"status":"Pending",'+
+                '"donationId":67,'+
+                '"donorId":410,'+
+                '"description":"Test description",'+
+                '"taskType":"Activity",'+
+                '"createdDate":1493077510493,'+
+                '"updtime":1487801043934,'+
+                '"completedDate":1487801043597'+
+            '}';
+    }
+}

--- a/src/pages/frSetup.page
+++ b/src/pages/frSetup.page
@@ -8,12 +8,12 @@
 			<apex:commandButton action="{!defaults}" value="Use Default Mappings" onclick="return confirm('This will delete ALL of your current mappings and replace them with the defaults.  Are you sure you want to continue?');" />
 		</apex:pageBlockButtons>
 		<h2>
-		Use this page to define what fields should be populated when a new donation (opportunity) or donor (contact) is sent from the 
+		Use this page to define what fields should be populated when a new donation (opportunity) or donor (contact) is sent from the
 		Funraise platform
 		</h2>
 		<br/> <br/>
 		<h2>
-		If you would prefer to hardcode a value for an opportunity or contact, check the "Constant?" box and enter the hardcoded value.  
+		If you would prefer to hardcode a value for an opportunity or contact, check the "Constant?" box and enter the hardcoded value.
 		If not, you can select a field value that comes from Funraise
 		</h2>
 	</apex:pageBlock>
@@ -38,7 +38,7 @@
 					<apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
 					<apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
 						<apex:selectOptions value="{!donationFROptions}" />
-					</apex:selectList> 
+					</apex:selectList>
 				</apex:column>
 				<apex:column >
 					<apex:facet name="header">
@@ -46,7 +46,7 @@
 					</apex:facet>
 					<apex:selectList value="{!mapping.sf_Name__c}" size="1">
 						<apex:selectOptions value="{!donationSFOptions}" />
-					</apex:selectList> 
+					</apex:selectList>
 				</apex:column>
 				<apex:column >
 					<apex:facet name="header">
@@ -84,7 +84,7 @@
 					<apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
 					<apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
 						<apex:selectOptions value="{!donorFROptions}" />
-					</apex:selectList> 
+					</apex:selectList>
 				</apex:column>
 				<apex:column >
 					<apex:facet name="header">
@@ -92,7 +92,7 @@
 					</apex:facet>
 					<apex:selectList value="{!mapping.sf_Name__c}" size="1">
 						<apex:selectOptions value="{!donorSFOptions}" />
-					</apex:selectList> 
+					</apex:selectList>
 				</apex:column>
 				<apex:column >
 					<apex:facet name="header">
@@ -106,6 +106,39 @@
 			</apex:pageBlockTable>
 			<apex:commandLink action="{!addMapping}" value="Add Donor Mapping" reRender="donorTable">
 				<apex:param name="type" value="{!DONOR_TYPE}" />
+			</apex:commandLink>
+		</apex:pageBlockSection>
+	</apex:pageBlock>
+
+	<apex:pageBlock title="Funraise Tag --> Salesforce Tag">
+		<apex:pageBlockSection columns="1">
+			<apex:pageBlockTable value="{!tagMappings}" var="mapping" id="tagTable" >
+				<apex:column id="fr-field-column">
+					<apex:facet name="header">
+						Value
+					</apex:facet>
+                    <apex:inputField value="{!mapping.fr_Name__c}" />
+				</apex:column>
+				<apex:column >
+					<apex:facet name="header">
+						Salesforce Tag
+					</apex:facet>
+					<apex:selectList value="{!mapping.sf_Name__c}" size="1">
+						<apex:selectOptions value="{!tagSFOptions}" />
+					</apex:selectList>
+				</apex:column>
+				<apex:column >
+					<apex:facet name="header">
+						Remove
+					</apex:facet>
+					<apex:commandLink action="{!removeMapping}" value="Remove" rendered="{!mapping.id != null}">
+						<apex:param name="id" value="{!mapping.Id}" />
+						<apex:param name="type" value="{!TAG_TYPE}" />
+					</apex:commandLink>
+				</apex:column>
+			</apex:pageBlockTable>
+			<apex:commandLink action="{!addMapping}" value="Add Tag Mapping" reRender="tagTable">
+				<apex:param name="type" value="{!TAG_TYPE}" />
 			</apex:commandLink>
 		</apex:pageBlockSection>
 	</apex:pageBlock>


### PR DESCRIPTION
Orgs need to be able to sync and map FR donor tags to SF contact tags.
This story updates the manage package to allow tag mapping.

Managed Package Install Link:  https://login.salesforce.com/packaging/installPackage.apexp?p0=04t1C000000tel6

Resolves:  FUN-5498