### PR TITLE
Fixing logic for preventing creating a duplicate campaign member.

### DIFF
--- a/src/classes/frCampaign.cls
+++ b/src/classes/frCampaign.cls
@@ -110,6 +110,10 @@ public class frCampaign {
                 Boolean campaignMemberExists = [SELECT COUNT() FROM CampaignMember 
                                                 WHERE ContactId = :donor.getContactId() 
                                                 AND CampaignId = :newCampaign.Id] > 0;
+                if(campaignMemberExists) {
+                    return;
+                }
+                
                 CampaignMember fundraiserMember = new CampaignMember(
                     CampaignId = newCampaign.Id,
                     ContactId = donor.getContactId()
@@ -119,7 +123,7 @@ public class frCampaign {
                 } catch (DMLException e) {
                     insert new Error__c(Error__c =
                                         'Failed to insert funraise campaign member for campaign id ' + goalId +
-                                        'supporter id: ' + supporterId + '. Exception: ' + e.getMessage());
+                                        ' supporter id: ' + supporterId + '. Exception: ' + e.getMessage());
                     return;
                 }
                 

--- a/src/classes/frCampaignTest.cls
+++ b/src/classes/frCampaignTest.cls
@@ -192,10 +192,12 @@ public class frCampaignTest {
         request.put('deleted', false);
 
         Test.startTest();
+        Integer startingErrors = [SELECT COUNT() FROM Error__c];
         new frCampaign(request);
         
         //the same request twice shouldn't duplicate campaign members
         new frCampaign(request);
+        Integer afterErrors = [SELECT COUNT() FROM Error__c];
         Test.stopTest();
 
         Campaign newCampaign = [SELECT Id, fr_ID__c, Name FROM Campaign WHERE fr_ID__c = :goalId];
@@ -205,6 +207,7 @@ public class frCampaignTest {
         System.assertEquals(1, members.size(), 'There should be a CampaignMember for the Fundraiser');
         CampaignMember fundraiserMember = members.get(0);
         System.assertEquals(fundraiser.Id, fundraiserMember.ContactId, 'There should be a CampaignMember for the Fundraiser');
+        System.assertEquals(startingErrors, afterErrors, 'No errors were expected, even in the case of duplicate requests');
     }
     
     static void createCampaigns() {

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -40,11 +40,7 @@
 @isTest
 public class frDonorTest {
     static testMethod void fromContact_test() {
-        Contact testContact = new Contact(
-            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
-            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ', 
-            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = '123456'
-        );
+        Contact testContact = getTestContact();
         insert testContact;
 
         Test.startTest();
@@ -87,5 +83,13 @@ public class frDonorTest {
 
         System.assertEquals(null, donor, 
             'The donor was retrieved when it did not match the fr_ID__c field');
+    }
+    
+    public static Contact getTestContact() {
+        return new Contact(
+            FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',
+            MailingStreet = '1007 Mountain Drive', MailingCity = 'Gotham', MailingState = 'NJ', 
+            MailingPostalCode = '12345', MailingCountry = 'United States', fr_ID__c = '123456'
+        );
     }
 }


### PR DESCRIPTION
Fix test that was intended to catch this but was also written checking for the wrong error conditions

Resolving FUN-6938

Install link: 

https://login.salesforce.com/packaging/installPackage.apexp?p0=04t1C000000OD1Q


