### PR TITLE
Fix opportunity contact role mappings

### DIFF
--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -39,10 +39,16 @@
 */
 
 public class frDonation extends frModel {
+    //Donation statuses
     private static final String COMPLETE = 'Complete';
     private static final String PENDING = 'Pending';
     private static final String REFUNDED = 'Refunded';
     private static final String FAILED = 'Failed';
+    
+    //Opportunity Contact Role types
+    @TestVisible private static final String OPP_ROLE_DONOR = 'Donor';
+    @TestVisible private static final String OPP_ROLE_FUNDRAISER = 'Fundraiser';
+    @TestVisible private static final String OPP_ROLE_TEAM_CAPTAIN = 'Team Captain';
     
     public static List<frMapping__c> mappings {
         get {
@@ -144,16 +150,75 @@ public class frDonation extends frModel {
         return isSuccess;
     }
     
-    public void createOpportunityMapping(Map<String, Object> request, String contactId) {
-        String mappingType = String.valueOf(request.get('opportunityRoleMapping'));
-        System.debug('Mapping Type: ' + mappingType);
-        if (mappingType != 'disabled' && mappingType != null) {
-            OpportunityContactRole role = new OpportunityContactRole();
-            role.ContactId = contactId;
-            role.OpportunityId = o.Id;
-            role.Role = mappingType;
-            insert role;
+    public void createOpportunityMapping(Map<String, Object> request) {
+        Boolean mappingDisabled = request.containsKey('opportunityContactMappingDisabled') ?
+            Boolean.valueOf(request.get('opportunityContactMappingDisabled')): true;
+        if (!mappingDisabled) {
+            String funraiseId = String.valueOf(request.get('id'));
+            String supporterId = String.valueOf(request.get('donorId'));
+            
+            Set<String> relatedSupporterFunraiseIds = new Set<String>{supporterId};
+            String fundraiserId = request.containsKey('fundraiserId') ? String.valueOf(request.get('fundraiserId')) : null;
+            if(String.isNotBlank(fundraiserId)) {
+                relatedSupporterFunraiseIds.add(fundraiserId);
+            }
+            String teamCaptainId = request.containsKey('teamCaptainId') ? String.valueOf(request.get('teamCaptainId')) : null;
+            if(String.isNotBlank(teamCaptainId)) {
+                relatedSupporterFunraiseIds.add(teamCaptainId);
+            }
+            Map<String, Contact> relatedContacts = new Map<String, Contact>();
+            for(Contact relatedContact : [SELECT Id, fr_Id__c, 
+                                          (SELECT Id, Role, ContactId FROM OpportunityContactRoles WHERE OpportunityId = :getOpportunityId()) 
+                                          from Contact WHERE fr_Id__c IN :relatedSupporterFunraiseIds]) {
+                relatedContacts.put(relatedContact.fr_Id__c, relatedContact);
+            }
+            
+            List<OpportunityContactRole> newContactRoles = new List<OpportunityContactRole>();
+            OpportunityContactRole donorRole = createRole(relatedContacts.get(supporterId), OPP_ROLE_DONOR);
+            if(donorRole != null) newContactRoles.add(donorRole);
+            
+            if(String.isNotBlank(fundraiserId)) {
+                if(!relatedContacts.containsKey(fundraiserId)) {
+                    insert new Error__c(Error__c =
+                                        'Failed to find related record: Contact with funraise id ' 
+                                        + fundraiserId+ 
+                                        ' for opportunity contact role '+ OPP_ROLE_FUNDRAISER +' for opportunity with funraise id ' 
+                                        + funraiseId);
+                } else {
+                    OpportunityContactRole fundraiserRole = createRole(relatedContacts.get(fundraiserId), OPP_ROLE_FUNDRAISER);
+                    if(fundraiserRole != null) newContactRoles.add(fundraiserRole);
+                }
+            }
+            if(String.isNotBlank(teamCaptainId)) {
+                if(!relatedContacts.containsKey(teamCaptainId)) {
+                    insert new Error__c(Error__c =
+                                        'Failed to find related record: Contact with funraise id ' 
+                                        + teamCaptainId+ 
+                                        ' for opportunity contact role '+ OPP_ROLE_TEAM_CAPTAIN +' for opportunity with funraise id ' 
+                                        + funraiseId);
+                } else {
+                    OpportunityContactRole captainRole = createRole(relatedContacts.get(teamCaptainId), OPP_ROLE_TEAM_CAPTAIN);
+                    if(captainRole != null) newContactRoles.add(captainRole);
+                }
+            }
+            
+            insert newContactRoles;
         }
+    }
+    
+    private OpportunityContactRole createRole(Contact supporter, String role) {
+        Set<String> existingRoles = new Set<String>();
+        for(OpportunityContactRole contactRole : supporter.OpportunityContactRoles) {
+            existingRoles.add(contactRole.Role);
+        }
+        if(!existingRoles.contains(role)) {
+            OpportunityContactRole newRole = new OpportunityContactRole();
+            newRole.ContactId = supporter.Id;
+            newRole.OpportunityId = getOpportunityId();
+            newRole.Role = role;
+            return newRole;
+        }
+        return null;
     }
     
     public String getDonorId() {

--- a/src/classes/frWSDonationController.cls
+++ b/src/classes/frWSDonationController.cls
@@ -57,11 +57,11 @@ global with sharing class frWSDonationController {
 
         Boolean isSuccess = donation.save();
         
-        /*
+        
         if (donor != null) {
-        	donation.createOpportunityMapping(request, donor.getContactId());
+        	donation.createOpportunityMapping(request);
         }
-		*/
+		
         
         Map<String,Object> resp = new Map<String,Object>();
         resp.put('id',donation.getOpportunityId());

--- a/src/classes/frWSDonationControllerTest.cls
+++ b/src/classes/frWSDonationControllerTest.cls
@@ -39,9 +39,6 @@
  */
 @isTest
 public class frWSDonationControllerTest {
-    private static void createMapping(String frField, String sfField) {
-        insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonation.TYPE);
-    }
     static testMethod void syncEntity_newDonor() {  
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
@@ -93,11 +90,8 @@ public class frWSDonationControllerTest {
     }
 
     static testMethod void syncEntity_existingDonor() { 
-        Contact testContact = new Contact(FirstName = 'Bruce', LastName = 'Wayne', 
-            Email = 'bruce.wayne@wayne.example.com', fr_ID__c = '856');
+        Contact testContact = frDonorTest.getTestContact();
         insert testContact;
-
-        Long currentMillis = Datetime.now().getTime();
 
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
@@ -116,17 +110,7 @@ public class frWSDonationControllerTest {
         Test.stopTest();
 
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        List<String> responseErrors = response.errors;
-        System.assertEquals(0, responseErrors.size(), 
-            'They were unexpected errors. Errors: '+responseErrors);
-        List<Error__c> errors = [SELECT Error__c FROM Error__c];
-        String errorsStr = '';
-        for(Error__c error : errors) {
-            errorsStr += error.Error__c + '\n';
-        }
-        System.assertEquals(0, errors.size(), 'There were unexpected errors. Errors:' + errorsStr);
-        System.assert(response.success, 'There were no errors expected, result should be successful save');
+        assertNoErrors(response);
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
@@ -138,15 +122,12 @@ public class frWSDonationControllerTest {
     
     
     static testMethod void syncEntity_CampaignDonation() { 
-        Contact testContact = new Contact(FirstName = 'Bruce', LastName = 'Wayne', 
-            Email = 'bruce.wayne@wayne.example.com', fr_ID__c = '856');
+        Contact testContact = frDonorTest.getTestContact();
         insert testContact;
         
         Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-
-        Long currentMillis = Datetime.now().getTime();
 
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
@@ -165,17 +146,7 @@ public class frWSDonationControllerTest {
         Test.stopTest();
 
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        List<String> responseErrors = response.errors;
-        System.assertEquals(0, responseErrors.size(), 
-            'They were unexpected errors. Errors: '+responseErrors);
-        List<Error__c> errors = [SELECT Error__c FROM Error__c];
-        String errorsStr = '';
-        for(Error__c error : errors) {
-            errorsStr += error.Error__c + '\n';
-        }
-        System.assertEquals(0, errors.size(), 'There were unexpected errors. Errors:' + errorsStr);
-        System.assert(response.success, 'There were no errors expected, result should be successful save');
+        assertNoErrors(response);
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
@@ -189,24 +160,119 @@ public class frWSDonationControllerTest {
     }
     
     static testMethod void syncEntity_donationStatusDefaulting() { 
-        Contact testContact = new Contact(FirstName = 'Bruce', LastName = 'Wayne', 
-            Email = 'bruce.wayne@wayne.example.com', fr_ID__c = '856');
+        Contact testContact = frDonorTest.getTestContact();
         insert testContact;
         
         Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
 
-        Long currentMillis = Datetime.now().getTime();
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
+        req.httpMethod = 'POST';
+        Map<String, Object> request = getTestRequest();
+        request.put('status', 'Refunded');
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+        Test.startTest();
+
+        frWSDonationController.syncEntity();
+
+        Test.stopTest();
+
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+        assertNoErrors(response);
+        
+        Id oppId = response.id;
+        System.assert(String.isNotBlank(oppId), 
+            'There was not an opportunity Id in the response as expected');
+        Opportunity newOpportunity = [SELECT Id, StageName, fr_ID__c, fr_Donor__c FROM Opportunity WHERE Id = :oppId];
+		System.assertEquals('Closed Lost', newOpportunity.StageName, 'A status of refunded should have resulted in a Closed Lost stage');
+    }
+    
+    static testMethod void syncEntity_newOpportunityRoleMappings() { 
+        Contact donor = frDonorTest.getTestContact();
+        donor.fr_Id__c = '1';
+        donor.Email = 'donor@example.com';
+        Contact fundraiser = frDonorTest.getTestContact();
+        fundraiser.fr_Id__c = '2';
+        fundraiser.Email = 'fundraiser@example.com';
+        Contact teamCaptain = frDonorTest.getTestContact();
+        teamCaptain.fr_Id__c = '3';
+        teamCaptain.Email = 'teamCaptain@example.com';
+        insert new List<Contact>{donor, fundraiser, teamCaptain};
 
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
 
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
-        String payload = getTestPayload();
-        payload = payload.replace('"status":"Complete"', '"status":"Refunded"');
-        req.requestBody = Blob.valueOf(payload);
+        Map<String, Object> request = getTestRequest();
+        request.put('opportunityContactMappingDisabled', 'false');
+        request.put('donorId', donor.fr_Id__c);
+        request.put('fundraiserId', fundraiser.fr_ID__c);
+        request.put('teamCaptainId', teamCaptain.fr_ID__c);
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+        Test.startTest();
+
+        frWSDonationController.syncEntity();
+
+        Test.stopTest();
+
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+        assertNoErrors(response);
+        
+        Id oppId = response.id;
+        System.assert(String.isNotBlank(oppId), 
+            'There was not an opportunity Id in the response as expected');
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE Id = :oppId];
+        List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
+        System.assertEquals(3, roles.size(), 'Expected to be a role for donor, fundraiser, and team captain');
+        for(OpportunityContactRole role : roles) {
+            if(role.Role == frDonation.OPP_ROLE_DONOR) {
+                System.assertEquals(donor.Id, role.ContactId, 'The donor should have the donor opportunity role');                
+            } else if(role.Role == frDonation.OPP_ROLE_FUNDRAISER) {
+                System.assertEquals(fundraiser.Id, role.ContactId, 'The fundraiser should have the fundraiser opportunity role');                
+            } else if(role.Role == frDonation.OPP_ROLE_TEAM_CAPTAIN) {
+                System.assertEquals(teamCaptain.Id, role.ContactId, 'The team captain should have the team captain opportunity role');                
+            } else {
+                System.assert(false, 'An unexpected opportunity contact role was created from a funraise request');
+            }
+        }
+    }
+    
+    static testMethod void syncEntity_newOpportunityRoleMappings_missingContacts() { 
+        Contact donor = frDonorTest.getTestContact();
+        donor.fr_Id__c = '1';
+        donor.Email = 'donor@example.com';
+        Contact fundraiser = frDonorTest.getTestContact();
+        fundraiser.fr_Id__c = '2';
+        fundraiser.Email = 'fundraiser@example.com';
+        Contact teamCaptain = frDonorTest.getTestContact();
+        teamCaptain.fr_Id__c = '3';
+        teamCaptain.Email = 'teamCaptain@example.com';
+        insert new List<Contact>{donor, fundraiser, teamCaptain};
+
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
+        req.httpMethod = 'POST';
+        Map<String, Object> request = getTestRequest();
+        request.put('opportunityContactMappingDisabled', 'false');
+        request.put('donorId', donor.fr_Id__c);
+        request.put('fundraiserId', fundraiser.fr_ID__c+'1');
+        request.put('teamCaptainId', teamCaptain.fr_ID__c+'1');
+        req.requestBody = Blob.valueOf(Json.serialize(request));
         RestContext.request = req;
         RestContext.response = res;
         createMapping('name', 'Name');
@@ -219,6 +285,16 @@ public class frWSDonationControllerTest {
 
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         
+        Id oppId = response.id;
+        System.assert(String.isNotBlank(oppId), 
+            'There was not an opportunity Id in the response as expected');
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE Id = :oppId];
+        List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
+        System.assertEquals(1, roles.size(), 'Since the request had ids that did not exist in SF, no roles should have been created except for the donor');
+        System.assertEquals(2, [SELECT COUNT() FROM Error__c], 'There should be 3 error logs for missing supporters that prevented opp roles from being created');
+    }
+    
+    private static void assertNoErrors(MockResponse response) {
         List<String> responseErrors = response.errors;
         System.assertEquals(0, responseErrors.size(), 
             'They were unexpected errors. Errors: '+responseErrors);
@@ -229,12 +305,10 @@ public class frWSDonationControllerTest {
         }
         System.assertEquals(0, errors.size(), 'There were unexpected errors. Errors:' + errorsStr);
         System.assert(response.success, 'There were no errors expected, result should be successful save');
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, StageName, fr_ID__c, fr_Donor__c FROM Opportunity WHERE Id = :oppId];
-		System.assertEquals('Closed Lost', newOpportunity.StageName, 'A status of refunded should have resulted in a Closed Lost stage');
+    }
+    
+    private static void createMapping(String frField, String sfField) {
+        insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonation.TYPE);
     }
 
     public class MockResponse {
@@ -244,58 +318,43 @@ public class frWSDonationControllerTest {
     }
 
     private static String getTestPayload() {
-        return 
-        '{"id":2048,'+
-        '"organizationId":"ae8d412b-db97-49dc-8c8c-5bfe0f41fc6d",'+
-        '"amount":1E+1,'+
-        '"name":"alex test02221503 - Funraise 2017-04-24T23:45:10.493Z",'+
-        '"donorId":856,'+
-        '"anonymous":false,'+
-        '"status":"Complete",'+
-        '"pledge":false,'+
-        '"formName":"Bitpay Widget Test",'+
-        '"url":"file:///home/alex/Desktop/form.html",'+
-        '"offline":false,'+
-        '"recurring":true,'+
-        '"memo":null,'+
-        '"dedicationMessage":null,'+
-        '"dedicationName":null,'+
-        '"dedicationEmail":null,'+
-        '"dedicationType":null,'+
-        '"tags":null,'+
-        '"recurringSequence":3,'+
-        '"operationsTip":false,'+
-        '"note":null,'+
-        '"campaignGoalId":null,'+
-        '"donation_cretime":1493077510493,'+
-        '"opportunityRoleMapping":"disabled"}';
+        return Json.serialize(getTestRequest());
     }
     
     private static String getTestPayloadCampaign() {
-        return 
-        '{"id":2048,'+
-        '"organizationId":"ae8d412b-db97-49dc-8c8c-5bfe0f41fc6d",'+
-        '"amount":1E+1,'+
-        '"name":"alex test02221503 - Funraise 2017-04-24T23:45:10.493Z",'+
-        '"donorId":856,'+
-        '"anonymous":false,'+
-        '"status":"Complete",'+
-        '"pledge":false,'+
-        '"formName":"Bitpay Widget Test",'+
-        '"url":"file:///home/alex/Desktop/form.html",'+
-        '"offline":false,'+
-        '"recurring":true,'+
-        '"memo":null,'+
-        '"dedicationMessage":null,'+
-        '"dedicationName":null,'+
-        '"dedicationEmail":null,'+
-        '"dedicationType":null,'+
-        '"tags":null,'+
-        '"recurringSequence":3,'+
-        '"operationsTip":false,'+
-        '"note":null,'+
-        '"campaignGoalId":"10",'+
-        '"donation_cretime":1493077510493,'+
-        '"opportunityRoleMapping":"disabled"}';
+        Map<String, Object> testRequest = getTestRequest();
+        testRequest.put('campaignGoalId', 10);
+        return Json.serialize(testRequest);
+    }
+    
+    private static Map<String, Object> getTestRequest() {
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('id', 2048);
+        request.put('organizationId', 'ae8d412b-db97-49dc-8c8c-5bfe0f41fc6d');
+        request.put('amount', 10);
+        request.put('name', 'alex test02221503 - Funraise 2017-04-24T23:45:10.493Z');
+        request.put('donorId', 123456);
+        request.put('anonymous', false);
+        request.put('status', 'Complete');
+        request.put('pledge', false);
+        request.put('formName', 'Bitpay Widget Test');
+        request.put('url', 'file:///home/alex/Desktop/form.html');
+        request.put('offline', false);
+        request.put('recurring', true);
+        request.put('memo', null);
+        request.put('dedicationMessage', null);
+        request.put('dedicationName', null);
+        request.put('dedicationEmail', null);
+        request.put('dedicationType', null);
+        request.put('tags', null);
+        request.put('recurringSequence', 3);
+        request.put('operationsTip', false);
+        request.put('note', null);
+        request.put('campaignGoalId', null);
+        request.put('donation_cretime', 1493077510493L);
+        request.put('opportunityContactMappingDisabled', 'true');
+        request.put('fundraiserId', null);
+        request.put('teamCaptainId', null);
+        return request;
     }
 }

--- a/src/objects/Fundraising_Event_Registration__c.object
+++ b/src/objects/Fundraising_Event_Registration__c.object
@@ -43,6 +43,7 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
+    <deprecated>false</deprecated>
     <enableActivities>false</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableChangeDataCapture>false</enableChangeDataCapture>
@@ -55,6 +56,7 @@
     <fields>
         <fullName>Attended__c</fullName>
         <defaultValue>false</defaultValue>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Attended</label>
         <trackTrending>false</trackTrending>
@@ -62,6 +64,7 @@
     </fields>
     <fields>
         <fullName>Fundraising_Event__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Funraise Event</label>
         <referenceTo>Fundraising_Event__c</referenceTo>
@@ -76,6 +79,7 @@
     <fields>
         <fullName>Guest_Of__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Guest Of</label>
         <referenceTo>Contact</referenceTo>
@@ -87,6 +91,7 @@
     </fields>
     <fields>
         <fullName>Supporter__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Supporter</label>
         <referenceTo>Contact</referenceTo>
@@ -100,6 +105,7 @@
     </fields>
     <fields>
         <fullName>Ticket_Name__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Ticket Name</label>
         <length>255</length>
@@ -110,6 +116,7 @@
     </fields>
     <fields>
         <fullName>fr_ID__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>true</externalId>
         <label>Funraise ID</label>
         <length>255</length>

--- a/src/objects/Fundraising_Event__c.object
+++ b/src/objects/Fundraising_Event__c.object
@@ -43,6 +43,7 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
+    <deprecated>false</deprecated>
     <enableActivities>false</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableChangeDataCapture>false</enableChangeDataCapture>
@@ -54,6 +55,7 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Description__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Description</label>
         <length>131072</length>
@@ -63,6 +65,7 @@
     </fields>
     <fields>
         <fullName>End_Date__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>End Date</label>
         <required>false</required>
@@ -71,6 +74,7 @@
     </fields>
     <fields>
         <fullName>Start_Date__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Start Date</label>
         <required>false</required>
@@ -79,6 +83,7 @@
     </fields>
     <fields>
         <fullName>fr_ID__c</fullName>
+        <deprecated>false</deprecated>
         <externalId>true</externalId>
         <label>Funraise ID</label>
         <length>255</length>


### PR DESCRIPTION
Instead of there being a single property, all possible contact roles are sent (currently donor, fundraiser, team captain) along with a boolean for if it is disabled on the platform side.

Add a test to confirm this functionality, uncomment out line in frWSDonationController
Resolving FUN-6909

Beta install link: https://login.salesforce.com/packaging/installPackage.apexp?p0=04t1C000000OD2s