### PR TITLE
Adding LastName to our SOQL queries for matching against an existing Contact

### DIFF
--- a/src/classes/frDonor.cls
+++ b/src/classes/frDonor.cls
@@ -66,7 +66,7 @@ public class frDonor extends frModel {
         Contact supporterContact = null;
         String frId = String.valueOf(request.get('id'));
         //try to find a donor that's already been integrated, use their funraise ID
-        List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c from Contact where fr_ID__c = :frId');
+        List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where fr_ID__c = :frId');
         if(contacts != null && contacts.size() > 0) {
             supporterContact = contacts.get(0);
         }
@@ -75,7 +75,7 @@ public class frDonor extends frModel {
             String email = String.valueOf(request.get('email'));
             //next try email, dont try to match on blank emails
             if(!String.isBlank(email)) {
-                contacts = (List<Contact>)Database.query('select Id, fr_ID__c from Contact where Email = :email order by CreatedDate desc limit 1');
+                contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where Email = :email order by CreatedDate desc limit 1');
                 if(contacts != null && contacts.size() > 0) {
                     supporterContact = contacts.get(0);
                     supporterContact.fr_ID__c = frId;
@@ -94,7 +94,7 @@ public class frDonor extends frModel {
             String lastName = String.valueOf(request.get('lastName'));
 
             //try to match by address, in case we sync an offline donation over with no email.
-            String byAddress = 'select Id, fr_ID__c from Contact where MailingStreet = :address1' +
+            String byAddress = 'select Id, fr_ID__c, LastName from Contact where MailingStreet = :address1' +
                                ' and MailingCity = :city' +
                                ' and MailingState = :state' +
                                ' and MailingPostalCode = :postalCode' +

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -89,7 +89,6 @@ public class frDonorTest {
         RestContext.response = res;
         
         createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
         createMapping('email', 'email');
         createMapping('address1', 'MailingStreet');
         createMapping('city', 'MailingCity');
@@ -110,6 +109,50 @@ public class frDonorTest {
                       'There was not an contact Id in the response as expected');
         Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE Id = :contactId];
         System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
+        System.assertEquals(String.valueOf(requestBody.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
+    }
+    
+    //Sync to an existing contact that once the mappings are applied, LastName is empty so Salesforce will throw an exception
+    //confirm our fallback works as expected to prevent that exception
+    static testMethod void syncEntity_contactLastNameFallback_existing() {
+		Contact existingSupporter = getTestContact();
+        insert existingSupporter;
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
+        req.httpMethod = 'POST';
+        Map<String, Object> requestBody = getTestRequest();
+        requestBody.put('id', existingSupporter.fr_Id__c);
+        requestBody.put('lastName', null);
+        requestBody.put('institutionName', 'Test Inst Name');
+        req.requestBody = Blob.valueOf(Json.serialize(requestBody));
+        RestContext.request = req;
+        RestContext.response = res;
+        
+        createMapping('firstName', 'FirstName');
+        createMapping('lastName', 'LastName');
+        createMapping('email', 'email');
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry');
+        createMapping('donor_cretime', 'BirthDate');
+        Test.startTest();
+        
+        frWSDonorController.syncEntity();
+        
+        Test.stopTest();
+        
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+
+        Id contactId = response.id;
+        System.assert(String.isNotBlank(contactId), 
+                      'There was not an contact Id in the response as expected');
+        Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE Id = :contactId];
+        System.assertEquals(existingSupporter.fr_Id__c, newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
         System.assertEquals(String.valueOf(requestBody.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
     }
     


### PR DESCRIPTION
so that when we check it later it is available

We added the check previously to add protection against a mapping resulting in a contact not having a LastName which is a required field in Salesforce.  We need to make sure that that field can be read even when we are reading on existing records instead of new ones
Resolving FUN-8076

The line that was causing the exception: https://github.com/funraise/Funraise-Salesforce/pull/32/files#diff-ecb101bfa934111b51e92b6d1b38a424R120

install link: https://login.salesforce.com/packaging/installPackage.apexp?p0=04t1C000000AqVO