### PR TITLE
Adding new UTM fields for Donations

### DIFF
--- a/src/customMetadata/frField.utmCampaign.md
+++ b/src/customMetadata/frField.utmCampaign.md
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>UTM Campaign</label>
+    <protected>true</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">Donation</value>
+    </values>
+</CustomMetadata>

--- a/src/customMetadata/frField.utmContent.md
+++ b/src/customMetadata/frField.utmContent.md
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>UTM Content</label>
+    <protected>true</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">Donation</value>
+    </values>
+</CustomMetadata>

--- a/src/customMetadata/frField.utmMedium.md
+++ b/src/customMetadata/frField.utmMedium.md
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>UTM Medium</label>
+    <protected>false</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">Donation</value>
+    </values>
+</CustomMetadata>

--- a/src/customMetadata/frField.utmSource.md
+++ b/src/customMetadata/frField.utmSource.md
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>UTM Source</label>
+    <protected>true</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">Donation</value>
+    </values>
+</CustomMetadata>

--- a/src/customMetadata/frField.utmTerm.md
+++ b/src/customMetadata/frField.utmTerm.md
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>UTM Term</label>
+    <protected>true</protected>
+    <values>
+        <field>Type__c</field>
+        <value xsi:type="xsd:string">Donation</value>
+    </values>
+</CustomMetadata>


### PR DESCRIPTION
This will allow the managed package to map the 5 utm fields from Donations in Funraise to Opportunities in Salesforce