### PR TITLE
Add handling for campaign name possibly being too long 

### DIFF
--- a/src/classes/frCampaign.cls
+++ b/src/classes/frCampaign.cls
@@ -77,8 +77,8 @@ public class frCampaign {
         String goalId = String.valueOf(request.get('goalId'));
         
         Campaign newCampaign = new Campaign();
-        newCampaign.Name = String.valueOf(request.get('name'));
-        newCampaign.Description = String.valueOf(request.get('reason'));
+        newCampaign.Name = frUtil.truncateToFieldLength(Campaign.Name.getDescribe(), String.valueOf(request.get('name')));
+        newCampaign.Description = frUtil.truncateToFieldLength(Campaign.Description.getDescribe(), String.valueOf(request.get('reason')));
         newCampaign.Status = String.valueOf(request.get('status'));
         newCampaign.ExpectedRevenue = Decimal.valueOf(String.valueOf(request.get('goalAmount')));
         newCampaign.fr_ID__c = goalId;


### PR DESCRIPTION
for the campaign name field in Salesforce.  Reusing the truncateToFieldLength method that already exists for this

Resolving FUN-8996