### PR TITLE
When converting from datetime -> date use .date() instead of dateGMT()

### DIFF
--- a/src/classes/frUtil.cls
+++ b/src/classes/frUtil.cls
@@ -50,7 +50,7 @@ public class frUtil {
                     }
                     
                 } else {
-                    record.put(field, DateTime.newInstance((Long)value).dateGMT());
+                    record.put(field, DateTime.newInstance((Long)value).date());
                 }
             } else if(field.getDescribe().getType() == Schema.DisplayType.Double) {
                 record.put(field, Double.valueOf(value));


### PR DESCRIPTION
since we want to get the date in the users timezone rather than the date in GMT, as that can sometimes appear to be a different day from the users perspective

Resolving FUN-9022