### PR TITLE
Prevent an unnecessary error log from being generated

### DIFF
--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -10,7 +10,7 @@ public class frDonorEmails {
             email.subject = 'Funraise Email - ' + String.valueOf(request.get('subject'));
             email.MessageDate = DateTime.newInstance((Long)request.get('sentDate')).dateGMT();
             email.fr_Email_ID__c = funraiseId;
-            insert email;
+            Database.upsert(email, EmailMessage.Fields.fr_Email_ID__c, true);
             
             EmailMessageRelation emr = new EmailMessageRelation();
             emr.EmailMessageId = email.Id;

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -86,32 +86,6 @@ public class frDonorEmailsTest {
         System.assertEquals(null, responseEmailId, 'We did not expect the email to be created created when the supporter could not be found');
         System.assertEquals(1, [SELECT COUNT() FROM Error__c], 'There should be an error for not being able to find the related supporter');
     }
-
-    static testMethod void createEmailNoEmailId_test() {
-        String funraiseId = '123456';
-        Contact testContact = frDonorTest.getTestContact();
-        testContact.fr_ID__c = funraiseId;
-        insert testContact;
-
-        Map<String, Object> request = new Map<String, Object>();
-        request.put('donorId', funraiseId);
-        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        request.put('fromAddress', 'test111@funraise.io');
-        request.put('fromName', 'Bob Hope');
-        request.put('toAddress', 'notfunraise111@funraise.io');
-        request.put('statusCode', 202);
-        request.put('sentDate', 1536184380L);
-        request.put('subject', 'Hello there!');
-
-        Test.startTest();
-        String responseEmailId = frDonorEmails.create(request);
-        Test.stopTest();
-
-        frTestUtil.assertNoErrors();
-        EmailMessage newEmail = [SELECT fromAddress FROM EmailMessage WHERE Id = :responseEmailId];
-        System.assertEquals('test111@funraise.io', newEmail.fromAddress, 'The fromAddress was not correct');
-    }
     
     static testMethod void syncEntity_test() {
         Contact testContact = frDonorTest.getTestContact();

--- a/src/classes/frUtil.cls
+++ b/src/classes/frUtil.cls
@@ -1,4 +1,5 @@
 public class frUtil {
+    private static String FUNRAISE_ID_FIELD = 'fr_Id__c';
     public static String truncateToFieldLength(DescribeFieldResult describe, String value) { 
         return String.isNotBlank(value) && value.length() > describe.getLength() ? value.substring(0, describe.getLength()) : value;
     }
@@ -103,7 +104,7 @@ public class frUtil {
             DMLException dmlEx = (DMLException)ex;
             //If it's the race condition on fr_Id__c duplicate value, then ignore it.  Else, log it
             for(Integer i = 0; i < dmlEx.getNumDml(); i++) {
-                if(!(dmlEx.getDmlMessage(i).contains('fr_Id__c') && duplicateValueStatusCodes.contains(dmlEx.getDmlType(i)))) {
+                if(!(dmlEx.getDmlMessage(i).containsIgnoreCase(FUNRAISE_ID_FIELD) && duplicateValueStatusCodes.contains(dmlEx.getDmlType(i)))) {
                     logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());
                 }
             }

--- a/src/classes/frUtil.cls
+++ b/src/classes/frUtil.cls
@@ -95,8 +95,22 @@ public class frUtil {
         logError(errObject, recordId, error);
     }
     
+    private static Set<StatusCode> duplicateValueStatusCodes = 
+        new Set<StatusCode>{StatusCode.DUPLICATE_EXTERNAL_ID, StatusCode.DUPLICATE_VALUE};
+            
     public static void logException(Entity errObject, String recordId, Exception ex) {
-        logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());
+        if(ex instanceof DMLException) {
+            DMLException dmlEx = (DMLException)ex;
+            //If it's the race condition on fr_Id__c duplicate value, then ignore it.  Else, log it
+            for(Integer i = 0; i < dmlEx.getNumDml(); i++) {
+                if(!(dmlEx.getDmlMessage(i).contains('fr_Id__c') && duplicateValueStatusCodes.contains(dmlEx.getDmlType(i)))) {
+                    logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());
+                }
+            }
+            
+        } else {
+            logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());            
+        }
     }
     
     public static void logError(Entity errObject, String recordId, String error) {


### PR DESCRIPTION
Adding handling for not generating an Error__c log when a duplicate fr_Id__c is encountered.   This happens because Funraise may send the same donor a couple of times in quick succession.

Even though the first thing we do in this method is query by fr_id__c and perform an upsert on fr_Id__c, it is still possible for an exception to get thrown in certain race conditions.  In these cases, it isn't useful to surface an Error__c log to the user, as there isn't any action that needs to be taken.  Since it was syncs that happened at the same moment, we know the data would be the same.  There is a longer term plan to fix this inside Funraise, but for now we will swallow this specific exception
Resolving FUN-7747