### PR TITLE
Adding the ability for pledges to be tracked in Salesforce

### DIFF
--- a/src/applications/Funraise.app
+++ b/src/applications/Funraise.app
@@ -12,4 +12,5 @@
     <tabs>Fundraising_Event_Registration__c</tabs>
     <tabs>Error__c</tabs>
     <tabs>Subscription__c</tabs>
+    <tabs>Pledge__c</tabs>
 </CustomApplication>

--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -140,7 +140,9 @@ public class frDonation extends frModel {
         
         
         Boolean isPledge = Boolean.valueOf(request.get('pledge'));
-        if(!isPledge) {
+        Boolean alreadyMappedToPledge = [SELECT COUNT() FROM Opportunity 
+                                         WHERE fr_Id__c = :funraiseId AND Funraise_Pledge__c != null] > 0;
+        if(!isPledge && !alreadyMappedToPledge) {
             Pledge__c pledge = frPledge.findActive(opp.fr_Donor__c);
             opp.Funraise_Pledge__c = pledge != null ? pledge.Id : null;
         }

--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -82,7 +82,7 @@ public class frDonation extends frModel {
         o = new Opportunity();
         super.populateFromRequest(request);
         String funraiseId = String.valueOf(request.get('id'));
-
+        
         String status = String.valueOf(request.get('status'));
         
         if(String.isBlank(o.StageName)) {
@@ -121,7 +121,7 @@ public class frDonation extends frModel {
                     o.CampaignId = campaigns[0].Id;
                 } else {
                     frUtil.logRelationshipError(frUtil.Entity.DONATION, funraiseId, 
-                                            frUtil.Entity.CAMPAIGN, campaignId);
+                                                frUtil.Entity.CAMPAIGN, campaignId);
                 }
             }
         }
@@ -144,7 +144,7 @@ public class frDonation extends frModel {
             Pledge__c pledge = frPledge.findActive(opp.fr_Donor__c);
             opp.Funraise_Pledge__c = pledge != null ? pledge.Id : null;
         }
-
+        
         try {
             Database.upsert(opp, Opportunity.Fields.fr_Id__c, true);
         } catch (Exception ex) {
@@ -167,7 +167,7 @@ public class frDonation extends frModel {
         String supporterId = String.valueOf(request.get('donorId'));
         
         Set<String> relatedSupporterFunraiseIds = new Set<String>{supporterId};
-        
+            
         String fundraiserId = request.containsKey('fundraiserId') ? String.valueOf(request.get('fundraiserId')) : null;
         if(String.isNotBlank(fundraiserId)) {
             relatedSupporterFunraiseIds.add(fundraiserId);
@@ -185,8 +185,8 @@ public class frDonation extends frModel {
         for(Contact relatedContact : [SELECT Id, fr_Id__c, 
                                       (SELECT Id, Role, ContactId FROM OpportunityContactRoles WHERE OpportunityId = :getOpportunityId()) 
                                       from Contact WHERE fr_Id__c IN :relatedSupporterFunraiseIds]) {
-			relatedContacts.put(relatedContact.fr_Id__c, relatedContact);
-        }
+                                          relatedContacts.put(relatedContact.fr_Id__c, relatedContact);
+                                      }
         
         List<OpportunityContactRole> newContactRoles = new List<OpportunityContactRole>();
         OpportunityContactRole donorRole = createRole(OPP_ROLE_DONOR, supporterId, relatedContacts, funraiseId);
@@ -223,7 +223,7 @@ public class frDonation extends frModel {
         if(!contactsByFunraiseId.containsKey(funraiseSupporterId)) {
             frUtil.logRelationshipError(frUtil.Entity.DONATION, funraiseDonationId, 
                                         frUtil.Entity.SUPPORTER, funraiseSupporterId,
-                                       'Opportunity Contact Role: '+ role);
+                                        'Opportunity Contact Role: '+ role);
             return null;
         }
         

--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -51,6 +51,9 @@ public class frDonation extends frModel {
     @TestVisible private static final String OPP_ROLE_TEAM_CAPTAIN = 'Team Captain';
     @TestVisible private static final String OPP_ROLE_SOFT_CREDIT = 'Soft Credit';
     
+    private static final String META_OPP_CONTACT_MAPPING_KEY = 'opportunityContactMappingDisabled';
+    private static final String META_CAMPAIGN_MAPPING_KEY = 'campaignMappingDisabled';
+    
     public static List<frMapping__c> mappings {
         get {
             if(mappings == null) {
@@ -108,8 +111,8 @@ public class frDonation extends frModel {
             }
         }
         
-        Boolean campaignMappingDisabled = request.containsKey('campaignMappingDisabled') ?
-            Boolean.valueOf(request.get('campaignMappingDisabled')): true;
+        Boolean campaignMappingDisabled = request.containsKey(META_CAMPAIGN_MAPPING_KEY) ?
+            Boolean.valueOf(request.get(META_CAMPAIGN_MAPPING_KEY)): true;
         if(!campaignMappingDisabled) {
             String campaignId = String.valueOf(request.get('campaignGoalId'));
             if (String.isNotBlank(campaignId)) {
@@ -133,18 +136,29 @@ public class frDonation extends frModel {
                                             frUtil.Entity.SUBSCRIPTION, subscriptionId);
             }
         }
+        Opportunity opp = getOpportunity();
         
+        
+        Boolean isPledge = Boolean.valueOf(request.get('pledge'));
+        if(!isPledge) {
+            Pledge__c pledge = frPledge.findActive(opp.fr_Donor__c);
+            opp.Funraise_Pledge__c = pledge != null ? pledge.Id : null;
+        }
+
         try {
-            Opportunity opp = getOpportunity();
             Database.upsert(opp, Opportunity.Fields.fr_Id__c, true);
         } catch (Exception ex) {
             frUtil.logException(frUtil.Entity.DONATION, funraiseId, ex);
         }
+        
+        if(isPledge) {
+            frPledge.create(opp);
+        }
     }
     
     public void createOpportunityMapping(Map<String, Object> request) {
-        Boolean mappingDisabled = request.containsKey('opportunityContactMappingDisabled') ?
-            Boolean.valueOf(request.get('opportunityContactMappingDisabled')): true;
+        Boolean mappingDisabled = request.containsKey(META_OPP_CONTACT_MAPPING_KEY) ?
+            Boolean.valueOf(request.get(META_OPP_CONTACT_MAPPING_KEY)): true;
         if(mappingDisabled) {
             return;
         }

--- a/src/classes/frDonationTest.cls
+++ b/src/classes/frDonationTest.cls
@@ -334,10 +334,7 @@ public class frDonationTest {
         Contact testSupporter = frDonorTest.getTestContact();
         insert testSupporter;
         
-        Pledge__c pledge = new Pledge__c(
-            Supporter__c = testSupporter.Id,
-            Pledge_Amount__c = 500
-        );
+        Pledge__c pledge = getTestPledge(testSupporter);
         insert pledge;
         
         RestRequest req = new RestRequest();
@@ -414,6 +411,57 @@ public class frDonationTest {
         System.assertEquals(pledge.Received_Amount__c, opp.Amount, 'The receive amount should be the same as the opportunity amount since the opp is Closed Won');
     }
     
+    /*
+    * Ensure that if a donation is already linked with a pledge
+    * it does not get overwritten by subsequent syncs when there may not 
+    * be an active pledge
+    */
+    static testMethod void syncEntity_existing_alreadyLinkedToPledge() {  
+        Contact testSupporter = frDonorTest.getTestContact();
+        insert testSupporter;
+        Pledge__c pledge = getTestPledge(testSupporter);
+        pledge.End_Date__c = Date.today().addDays(-1); //so it's no longer active
+        insert pledge;
+        Opportunity existingOpp = getTestOpp();
+        existingOpp.fr_Id__c = '2048';
+        existingOpp.Funraise_Pledge__c = pledge.Id;
+        insert existingOpp;
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
+        req.httpMethod = 'POST';
+        
+        Map<String, Object> request = getTestRequest();
+        request.put('id', existingOpp.fr_Id__c);
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        
+        RestContext.request = req;
+        RestContext.response = res;
+        
+        createMapping('name', 'Name');
+        createMapping('amount', 'amount');
+        createMapping('donation_cretime', 'CloseDate');
+        
+        Test.startTest();
+        
+        frWSDonationController.syncEntity();
+        
+        Test.stopTest();
+        
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+        frTestUtil.assertNoErrors();
+        
+        Id oppId = response.id;
+        System.assert(String.isNotBlank(oppId), 
+                      'There was not an opportunity Id in the response as expected');
+        Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        System.assertEquals(pledge.Id, opp.Funraise_Pledge__c, 'The pledge value should remain unchanged');
+        System.assertNotEquals(null, opp.Funraise_Pledge__c, 'The new donation should have created a new pledge');
+        
+    }
+    
     private static void createMapping(String frField, String sfField) {
         insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonation.TYPE);
     }
@@ -470,5 +518,13 @@ public class frDonationTest {
             StageName = 'Closed Won', 
             Name = 'Unit Test Opportunity'
         );
+    }
+    
+    public static Pledge__c getTestPledge(Contact supporter) {
+        Pledge__c pledge = new Pledge__c(
+            Supporter__c = supporter.Id,
+            Pledge_Amount__c = 500
+        );
+		return pledge;
     }
 }

--- a/src/classes/frDonationTest.cls
+++ b/src/classes/frDonationTest.cls
@@ -330,6 +330,90 @@ public class frDonationTest {
         System.assertEquals(subscription.Id, newOpportunity.Subscription__c, 'The new donation should be pointing at the subscription corresponding to the id provided in the request');
     }
     
+    static testMethod void syncEntity_LinkToPledge() {  
+        Contact testSupporter = frDonorTest.getTestContact();
+        insert testSupporter;
+        
+        Pledge__c pledge = new Pledge__c(
+        	Supporter__c = testSupporter.Id,
+            Pledge_Amount__c = 500
+        );
+        insert pledge;
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
+        req.httpMethod = 'POST';
+
+        Map<String, Object> request = getTestRequest();
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+
+        RestContext.request = req;
+        RestContext.response = res;
+
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+
+        Test.startTest();
+
+        frWSDonationController.syncEntity();
+
+        Test.stopTest();
+
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+        frTestUtil.assertNoErrors();
+        
+        Id oppId = response.id;
+        System.assert(String.isNotBlank(oppId), 
+            'There was not an opportunity Id in the response as expected');
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        System.assertEquals(pledge.Id, newOpportunity.Funraise_Pledge__c, 'The new donation should be pointing at the pledge that the supporter had active');
+    }
+    
+    static testMethod void syncEntity_PledgeCreatesPledge() {  
+        Contact testSupporter = frDonorTest.getTestContact();
+        insert testSupporter;
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
+        req.httpMethod = 'POST';
+
+        Map<String, Object> request = getTestRequest();
+        request.put('pledge', true);
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+
+        RestContext.request = req;
+        RestContext.response = res;
+
+        createMapping('name', 'Name');
+        createMapping('amount', 'amount');
+        createMapping('donation_cretime', 'CloseDate');
+
+        Test.startTest();
+
+        frWSDonationController.syncEntity();
+
+        Test.stopTest();
+
+        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
+        frTestUtil.assertNoErrors();
+        
+        Id oppId = response.id;
+        System.assert(String.isNotBlank(oppId), 
+            'There was not an opportunity Id in the response as expected');
+        Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        System.assertNotEquals(null, opp.Funraise_Pledge__c, 'The new donation should have created a new pledge');
+        Pledge__c pledge = [SELECT Pledge_Donation_uq__c , Pledge_Donation__c, Pledge_Amount__c, Received_Amount__c from Pledge__c
+                                    WHERE Id = :opp.Funraise_Pledge__c];
+		System.assertEquals(pledge.Pledge_Donation_uq__c, opp.Id, 'The one-time pledge should have a reference to the one-time donation that created it');
+		System.assertEquals(pledge.Pledge_Donation__c, opp.Id, 'The one-time pledge should have a reference to the one-time donation that created it');
+        System.assertEquals(pledge.Pledge_Amount__c, opp.Amount, 'The pledged amount should be the same as the opportunity amount');
+        System.assertEquals(pledge.Received_Amount__c, opp.Amount, 'The receive amount should be the same as the opportunity amount since the opp is Closed Won');
+    }
+    
     private static void createMapping(String frField, String sfField) {
         insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonation.TYPE);
     }
@@ -378,5 +462,13 @@ public class frDonationTest {
         request.put('fundraiserId', null);
         request.put('teamCaptainId', null);
         return request;
+    }
+    
+    public static Opportunity getTestOpp() {
+        return new Opportunity(
+            CloseDate = Date.today(), 
+            StageName = 'Closed Won', 
+            Name = 'Unit Test Opportunity'
+        );
     }
 }

--- a/src/classes/frDonationTest.cls
+++ b/src/classes/frDonationTest.cls
@@ -1,56 +1,56 @@
 /*
- *
- *  Copyright (c) 2020, Funraise Inc
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *  1. Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *  3. All advertising materials mentioning features or use of this software
- *     must display the following acknowledgement:
- *     This product includes software developed by the <organization>.
- *  4. Neither the name of the <organization> nor the
- *     names of its contributors may be used to endorse or promote products
- *     derived from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
- *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
- *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *
- *
- * PURPOSE:
- *
- *
- *
- * CREATED: 2019 Funraise Inc - https://funraise.io
- * AUTHOR: Alex Molina
- */
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:
+*
+*
+*
+* CREATED: 2019 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
 @isTest
 public class frDonationTest {
     static testMethod void syncEntity_newDonor() {  
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
-
+        
         req.requestBody = Blob.valueOf(getTestPayload());
-
+        
         RestContext.request = req;
         RestContext.response = res;
-
+        
         createMapping('name', 'Name');
         createMapping('name', 'Description');
         createMapping('amount', 'amount');
@@ -58,24 +58,24 @@ public class frDonationTest {
         insert new frMapping__c(Name = 'Test String', Is_Constant__c = true, Constant_Value__c = 'Closed Won', sf_Name__c = 'StageName', Type__c = frDonation.TYPE);
         insert new frMapping__c(Name = 'Test Percent', Is_Constant__c = true, Constant_Value__c = '95', sf_Name__c = 'Probability', Type__c = frDonation.TYPE);
         insert new frMapping__c(Name = 'Test Double', Is_Constant__c = true, Constant_Value__c = '1.5', sf_Name__c = 'totalopportunityquantity', Type__c = frDonation.TYPE);
-
+        
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         
-		List<Error__c> errors = [SELECT Id, Name, Error__c from Error__c];
+        List<Error__c> errors = [SELECT Id, Name, Error__c from Error__c];
         System.assertEquals(1, errors.size(), 
-            'They were unexpected errors. Errors: '+errors);
+                            'They were unexpected errors. Errors: '+errors);
         System.assert(errors.get(0).Error__c.contains('Failed to find related record'), 
-            'The error message was not the expected one');
+                      'The error message was not the expected one');
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, StageName, Name, Description, Probability, TotalOpportunityQuantity FROM Opportunity WHERE Id = :oppId];
         System.assertEquals('Closed Won', newOpportunity.StageName, 'The constant mapping for StageName was not used');
         System.assertEquals(95, newOpportunity.Probability, 'The constant mapping for Probability was not used');
@@ -86,14 +86,14 @@ public class frDonationTest {
         System.assertEquals(expectedNameAndDesc, newOpportunity.Name, 'The mapping for name should have been applied');
         System.assertEquals(expectedNameAndDesc, newOpportunity.Description, 'The mapping for desc should have been applied');
     }
-
+    
     static testMethod void syncEntity_existingDonor() { 
         Contact testContact = frDonorTest.getTestContact();
         insert testContact;
-
+        
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
         req.requestBody = Blob.valueOf(getTestPayload());
@@ -102,20 +102,20 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c FROM Opportunity WHERE Id = :oppId];
         System.assertEquals(testContact.Id, newOpportunity.fr_Donor__c, 
-            'The funraise sf donor id was not populated to the opportunity\'s contact lookup field');
+                            'The funraise sf donor id was not populated to the opportunity\'s contact lookup field');
     }
     
     
@@ -126,10 +126,10 @@ public class frDonationTest {
         Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-
+        
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
         req.requestBody = Blob.valueOf(getTestPayloadCampaign());
@@ -138,22 +138,22 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, CampaignId FROM Opportunity WHERE Id = :oppId];
         System.assertEquals(testContact.Id, newOpportunity.fr_Donor__c, 
-            'The funraise sf donor id was not populated to the opportunity\'s contact lookup field');
+                            'The funraise sf donor id was not populated to the opportunity\'s contact lookup field');
         System.assertEquals(testCampaign.Id, newOpportunity.CampaignId, 
-            'The campaign Id was not added to the donation');
+                            'The campaign Id was not added to the donation');
     }
     
     static testMethod void syncEntity_donationStatusDefaulting() { 
@@ -163,10 +163,10 @@ public class frDonationTest {
         Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-
+        
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
         Map<String, Object> request = getTestRequest();
@@ -177,19 +177,19 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, StageName, fr_ID__c, fr_Donor__c FROM Opportunity WHERE Id = :oppId];
-		System.assertEquals('Closed Lost', newOpportunity.StageName, 'A status of refunded should have resulted in a Closed Lost stage');
+        System.assertEquals('Closed Lost', newOpportunity.StageName, 'A status of refunded should have resulted in a Closed Lost stage');
     }
     
     static testMethod void syncEntity_newOpportunityRoleMappings() { 
@@ -203,10 +203,10 @@ public class frDonationTest {
         teamCaptain.fr_Id__c = '3';
         teamCaptain.Email = 'teamCaptain@example.com';
         insert new List<Contact>{donor, fundraiser, teamCaptain};
-
+            
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
         Map<String, Object> request = getTestRequest();
@@ -220,17 +220,17 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE Id = :oppId];
         List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
         System.assertEquals(3, roles.size(), 'Expected to be a role for donor, fundraiser, and team captain');
@@ -258,10 +258,10 @@ public class frDonationTest {
         teamCaptain.fr_Id__c = '3';
         teamCaptain.Email = 'teamCaptain@example.com';
         insert new List<Contact>{donor, fundraiser, teamCaptain};
-
+            
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
         Map<String, Object> request = getTestRequest();
@@ -275,16 +275,16 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE Id = :oppId];
         List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
         System.assertEquals(1, roles.size(), 'Since the request had ids that did not exist in SF, no roles should have been created except for the donor');
@@ -300,32 +300,32 @@ public class frDonationTest {
         
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
-
+        
         Map<String, Object> request = getTestRequest();
         request.put('subscriptionId', subscription.fr_ID__c);
         req.requestBody = Blob.valueOf(Json.serialize(request));
-
+        
         RestContext.request = req;
         RestContext.response = res;
-
+        
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-
+        
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, Subscription__c FROM Opportunity WHERE Id = :oppId];
         System.assertEquals(subscription.Id, newOpportunity.Subscription__c, 'The new donation should be pointing at the subscription corresponding to the id provided in the request');
     }
@@ -335,38 +335,38 @@ public class frDonationTest {
         insert testSupporter;
         
         Pledge__c pledge = new Pledge__c(
-        	Supporter__c = testSupporter.Id,
+            Supporter__c = testSupporter.Id,
             Pledge_Amount__c = 500
         );
         insert pledge;
         
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
-
+        
         Map<String, Object> request = getTestRequest();
         req.requestBody = Blob.valueOf(Json.serialize(request));
-
+        
         RestContext.request = req;
         RestContext.response = res;
-
+        
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-
+        
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
         System.assertEquals(pledge.Id, newOpportunity.Funraise_Pledge__c, 'The new donation should be pointing at the pledge that the supporter had active');
     }
@@ -377,39 +377,39 @@ public class frDonationTest {
         
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
-
+        
         req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
         req.httpMethod = 'POST';
-
+        
         Map<String, Object> request = getTestRequest();
         request.put('pledge', true);
         req.requestBody = Blob.valueOf(Json.serialize(request));
-
+        
         RestContext.request = req;
         RestContext.response = res;
-
+        
         createMapping('name', 'Name');
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
-
+        
         Test.startTest();
-
+        
         frWSDonationController.syncEntity();
-
+        
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
         Id oppId = response.id;
         System.assert(String.isNotBlank(oppId), 
-            'There was not an opportunity Id in the response as expected');
+                      'There was not an opportunity Id in the response as expected');
         Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
         System.assertNotEquals(null, opp.Funraise_Pledge__c, 'The new donation should have created a new pledge');
         Pledge__c pledge = [SELECT Pledge_Donation_uq__c , Pledge_Donation__c, Pledge_Amount__c, Received_Amount__c from Pledge__c
-                                    WHERE Id = :opp.Funraise_Pledge__c];
-		System.assertEquals(pledge.Pledge_Donation_uq__c, opp.Id, 'The one-time pledge should have a reference to the one-time donation that created it');
-		System.assertEquals(pledge.Pledge_Donation__c, opp.Id, 'The one-time pledge should have a reference to the one-time donation that created it');
+                            WHERE Id = :opp.Funraise_Pledge__c];
+        System.assertEquals(pledge.Pledge_Donation_uq__c, opp.Id, 'The one-time pledge should have a reference to the one-time donation that created it');
+        System.assertEquals(pledge.Pledge_Donation__c, opp.Id, 'The one-time pledge should have a reference to the one-time donation that created it');
         System.assertEquals(pledge.Pledge_Amount__c, opp.Amount, 'The pledged amount should be the same as the opportunity amount');
         System.assertEquals(pledge.Received_Amount__c, opp.Amount, 'The receive amount should be the same as the opportunity amount since the opp is Closed Won');
     }
@@ -417,11 +417,11 @@ public class frDonationTest {
     private static void createMapping(String frField, String sfField) {
         insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonation.TYPE);
     }
-
+    
     public class MockResponse {
         String id;
     }
-
+    
     private static String getTestPayload() {
         return Json.serialize(getTestRequest());
     }

--- a/src/classes/frDonor.cls
+++ b/src/classes/frDonor.cls
@@ -1,46 +1,46 @@
 /*
- *
- *  Copyright (c) 2020, Funraise Inc
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *  1. Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *  3. All advertising materials mentioning features or use of this software
- *     must display the following acknowledgement:
- *     This product includes software developed by the <organization>.
- *  4. Neither the name of the <organization> nor the
- *     names of its contributors may be used to endorse or promote products
- *     derived from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
- *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
- *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *
- *
- * PURPOSE:
- *
- *
- *
- * CREATED: 2016 Funraise Inc - https://funraise.io
- * AUTHOR: Jason M. Swenski
- */
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:
+*
+*
+*
+* CREATED: 2016 Funraise Inc - https://funraise.io
+* AUTHOR: Jason M. Swenski
+*/
 
 public class frDonor extends frModel {
     public static final String TYPE = 'Donor';
-
+    
     public static List<frMapping__c> mappings {
         get {
             if(mappings == null) {
@@ -50,18 +50,18 @@ public class frDonor extends frModel {
         }
         set;
     }
-
+    
     public override List<frMapping__c> getMappings() {
         return mappings;
     }
     protected override SObject getObject() {
         return c;
     }
-
+    
     private String contactId;
     private String id;
     private Contact c;
-
+    
     public frDonor(Map<String, Object> request) {
         Contact supporterContact = null;
         String frId = String.valueOf(request.get('id'));
@@ -70,7 +70,7 @@ public class frDonor extends frModel {
         if(contacts != null && contacts.size() > 0) {
             supporterContact = contacts.get(0);
         }
-
+        
         String firstName = String.valueOf(request.get('firstName'));
         String lastName = String.valueOf(request.get('lastName'));
         String email = String.valueOf(request.get('email'));
@@ -91,10 +91,10 @@ public class frDonor extends frModel {
                     contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where Email = :email limit 1 FOR UPDATE');
                     supporterContact = applyMatch(contacts, frId);                 
                 }
-
+                
             }
         }
-
+        
         if(supporterContact == null) {
             String address1 = String.valueOf(request.get('address1'));
             String city = String.valueOf(request.get('city'));
@@ -104,18 +104,18 @@ public class frDonor extends frModel {
             
             //try to match by address, in case we sync an offline donation over with no email.
             String byAddress = 'select Id, fr_ID__c, LastName from Contact where MailingStreet = :address1' +
-                               ' and MailingCity = :city' +
-                               ' and MailingState = :state' +
-                               ' and MailingPostalCode = :postalCode' +
-                               ' and MailingCountry = :country' +
-                               ' and FirstName = :firstName' +
-                               ' and LastName = :lastName' +
-                               ' limit 1 FOR UPDATE';
-
+                ' and MailingCity = :city' +
+                ' and MailingState = :state' +
+                ' and MailingPostalCode = :postalCode' +
+                ' and MailingCountry = :country' +
+                ' and FirstName = :firstName' +
+                ' and LastName = :lastName' +
+                ' limit 1 FOR UPDATE';
+            
             contacts = (List<Contact>)Database.query(byAddress);
             supporterContact = applyMatch(contacts, frId);
         }
-
+        
         if(supporterContact == null) {
             supporterContact = new Contact();
         }
@@ -126,7 +126,7 @@ public class frDonor extends frModel {
             //LastName is required.  If the mappings didn't populate it, try to populate with the institution name
             supporterContact.LastName = String.valueOf(request.get('institutionName'));
         }
-
+        
         try {
             Database.upsert(supporterContact, Contact.Fields.fr_ID__c, true);
         } catch (Exception ex) {
@@ -147,7 +147,7 @@ public class frDonor extends frModel {
     private void setContact(Contact contact) {
         this.c = contact;
     }
-
+    
     public Contact getContact() {
         return c;
     }

--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -10,7 +10,7 @@ public class frDonorEmails {
             email.subject = 'Funraise Email - ' + String.valueOf(request.get('subject'));
             email.MessageDate = DateTime.newInstance((Long)request.get('sentDate')).dateGMT();
             email.fr_Email_ID__c = funraiseId;
-            insert email;
+            Database.upsert(email, EmailMessage.Fields.fr_Email_ID__c, true);
             
             EmailMessageRelation emr = new EmailMessageRelation();
             emr.EmailMessageId = email.Id;

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -86,32 +86,6 @@ public class frDonorEmailsTest {
         System.assertEquals(null, responseEmailId, 'We did not expect the email to be created created when the supporter could not be found');
         System.assertEquals(1, [SELECT COUNT() FROM Error__c], 'There should be an error for not being able to find the related supporter');
     }
-
-    static testMethod void createEmailNoEmailId_test() {
-        String funraiseId = '123456';
-        Contact testContact = frDonorTest.getTestContact();
-        testContact.fr_ID__c = funraiseId;
-        insert testContact;
-
-        Map<String, Object> request = new Map<String, Object>();
-        request.put('donorId', funraiseId);
-        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        request.put('fromAddress', 'test111@funraise.io');
-        request.put('fromName', 'Bob Hope');
-        request.put('toAddress', 'notfunraise111@funraise.io');
-        request.put('statusCode', 202);
-        request.put('sentDate', 1536184380L);
-        request.put('subject', 'Hello there!');
-
-        Test.startTest();
-        String responseEmailId = frDonorEmails.create(request);
-        Test.stopTest();
-
-        frTestUtil.assertNoErrors();
-        EmailMessage newEmail = [SELECT fromAddress FROM EmailMessage WHERE Id = :responseEmailId];
-        System.assertEquals('test111@funraise.io', newEmail.fromAddress, 'The fromAddress was not correct');
-    }
     
     static testMethod void syncEntity_test() {
         Contact testContact = frDonorTest.getTestContact();

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -65,7 +65,7 @@ public class frDonorTest {
         Test.stopTest();
         
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-
+        
         Id contactId = response.id;
         System.assert(String.isNotBlank(contactId), 
                       'There was not an contact Id in the response as expected');
@@ -103,7 +103,7 @@ public class frDonorTest {
         Test.stopTest();
         
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-
+        
         Id contactId = response.id;
         System.assert(String.isNotBlank(contactId), 
                       'There was not an contact Id in the response as expected');
@@ -115,7 +115,7 @@ public class frDonorTest {
     //Sync to an existing contact that once the mappings are applied, LastName is empty so Salesforce will throw an exception
     //confirm our fallback works as expected to prevent that exception
     static testMethod void syncEntity_contactLastNameFallback_existing() {
-		Contact existingSupporter = getTestContact();
+        Contact existingSupporter = getTestContact();
         insert existingSupporter;
         
         RestRequest req = new RestRequest();
@@ -147,7 +147,7 @@ public class frDonorTest {
         Test.stopTest();
         
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-
+        
         Id contactId = response.id;
         System.assert(String.isNotBlank(contactId), 
                       'There was not an contact Id in the response as expected');
@@ -185,9 +185,9 @@ public class frDonorTest {
         frWSDonorController.syncEntity();
         
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-
+        
         Id contactId = response.id;
         System.assert(String.isNotBlank(contactId), 
                       'There was not an contact Id in the response as expected');
@@ -201,8 +201,8 @@ public class frDonorTest {
         Contact existing = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'alextest02221503@example.com');
         Contact noMatch = new Contact(LastName = 'nomatch', FirstName = 'nomatch', Email = 'nomatch@example.com', fr_ID__c = '111');
         insert new List<Contact>{existing, noMatch};
-        
-        Integer countBeforeSync = [SELECT COUNT() FROM Contact];
+            
+            Integer countBeforeSync = [SELECT COUNT() FROM Contact];
         
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
@@ -226,7 +226,7 @@ public class frDonorTest {
         frWSDonorController.syncEntity();
         
         Test.stopTest();
-
+        
         MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         
         Id contactId = response.id;

--- a/src/classes/frOpportunityPledgeCalculatorTriggerTest.cls
+++ b/src/classes/frOpportunityPledgeCalculatorTriggerTest.cls
@@ -1,42 +1,42 @@
 /*
- *
- *  Copyright (c) 2020, Funraise Inc
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *  1. Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *  3. All advertising materials mentioning features or use of this software
- *     must display the following acknowledgement:
- *     This product includes software developed by the <organization>.
- *  4. Neither the name of the <organization> nor the
- *     names of its contributors may be used to endorse or promote products
- *     derived from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
- *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
- *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *
- *
- * PURPOSE:  A test class for frOpportunityPledgeCalculator
- *
- *
- *
- * CREATED: 2020 Funraise Inc - https://funraise.io
- * AUTHOR: Alex Molina
- */
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:  A test class for frOpportunityPledgeCalculator
+*
+*
+*
+* CREATED: 2020 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
 @IsTest
 public class frOpportunityPledgeCalculatorTriggerTest {
     static testMethod void newOpp_withPledge() {  
@@ -63,7 +63,7 @@ public class frOpportunityPledgeCalculatorTriggerTest {
         
         Opportunity opp = createClosedOpportunity(supporter, null, 100);
         insert opp;
-            
+        
         Test.startTest();
         Decimal pledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :pledge.Id].Received_Amount__c;
         opp.Funraise_Pledge__c = pledge.Id;
@@ -81,10 +81,10 @@ public class frOpportunityPledgeCalculatorTriggerTest {
         Pledge__c oldPledge = createPledge(supporter);
         Pledge__c newPledge = createPledge(supporter);
         insert new List<Pledge__c>{newPledge, oldPledge};
-        
-        Opportunity opp = createClosedOpportunity(supporter, oldPledge, 100);
-        insert opp;
             
+            Opportunity opp = createClosedOpportunity(supporter, oldPledge, 100);
+        insert opp;
+        
         Test.startTest();
         Decimal oldPledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :oldPledge.Id].Received_Amount__c;
         Decimal newPledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :newPledge.Id].Received_Amount__c;
@@ -111,7 +111,7 @@ public class frOpportunityPledgeCalculatorTriggerTest {
         
         Opportunity opp = createClosedOpportunity(supporter, pledge, 100);
         insert opp;
-            
+        
         Test.startTest();
         Decimal pledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :pledge.Id].Received_Amount__c;
         delete opp;
@@ -123,7 +123,7 @@ public class frOpportunityPledgeCalculatorTriggerTest {
     }
     
     static Opportunity createClosedOpportunity(Contact supporter, Pledge__c pledge, Decimal amount) {
-		Opportunity opp = frDonationTest.getTestOpp();
+        Opportunity opp = frDonationTest.getTestOpp();
         OpportunityStage closedWonOppStage = [SELECT Id, ApiName FROM 
                                               OpportunityStage WHERE IsWon = true AND IsClosed = true
                                               AND IsActive = true];
@@ -136,7 +136,7 @@ public class frOpportunityPledgeCalculatorTriggerTest {
     
     static Pledge__c createPledge(Contact supporter) {
         return new Pledge__c(
-        	Name = 'Unit Test Pledge',
+            Name = 'Unit Test Pledge',
             Supporter__c = supporter.Id,
             Pledge_Amount__c = 100
         );

--- a/src/classes/frOpportunityPledgeCalculatorTriggerTest.cls
+++ b/src/classes/frOpportunityPledgeCalculatorTriggerTest.cls
@@ -1,0 +1,144 @@
+/*
+ *
+ *  Copyright (c) 2020, Funraise Inc
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. All advertising materials mentioning features or use of this software
+ *     must display the following acknowledgement:
+ *     This product includes software developed by the <organization>.
+ *  4. Neither the name of the <organization> nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ * PURPOSE:  A test class for frOpportunityPledgeCalculator
+ *
+ *
+ *
+ * CREATED: 2020 Funraise Inc - https://funraise.io
+ * AUTHOR: Alex Molina
+ */
+@IsTest
+public class frOpportunityPledgeCalculatorTriggerTest {
+    static testMethod void newOpp_withPledge() {  
+        Contact supporter = frDonorTest.getTestContact();
+        insert supporter;
+        Pledge__c pledge = createPledge(supporter);
+        insert pledge;
+        
+        Opportunity opp = createClosedOpportunity(supporter, pledge, 100);
+        
+        Test.startTest();
+        insert opp;
+        Test.stopTest();
+        
+        pledge = [SELECT Id, Received_Amount__c FROM Pledge__c WHERE Id = :pledge.Id];
+        System.assertEquals(opp.Amount, pledge.Received_Amount__c, 'The pledge received amount should have been the opp amount');
+    }
+    
+    static testMethod void existingOpp_withNewPledge() {  
+        Contact supporter = frDonorTest.getTestContact();
+        insert supporter;
+        Pledge__c pledge = createPledge(supporter);
+        insert pledge;
+        
+        Opportunity opp = createClosedOpportunity(supporter, null, 100);
+        insert opp;
+            
+        Test.startTest();
+        Decimal pledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :pledge.Id].Received_Amount__c;
+        opp.Funraise_Pledge__c = pledge.Id;
+        update opp;
+        Decimal pledgeAmountAfter = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :pledge.Id].Received_Amount__c;
+        Test.stopTest();
+        
+        System.assertEquals(null, pledgeAmountBefore, 'The pledge received amount should have been null since there were no opps associated');
+        System.assertEquals(opp.Amount, pledgeAmountAfter, 'The pledge received amount should have been the amount of the opp that was updated to reference it');
+    }
+    
+    static testMethod void existingOpp_withNewAndOldPledge() {  
+        Contact supporter = frDonorTest.getTestContact();
+        insert supporter;
+        Pledge__c oldPledge = createPledge(supporter);
+        Pledge__c newPledge = createPledge(supporter);
+        insert new List<Pledge__c>{newPledge, oldPledge};
+        
+        Opportunity opp = createClosedOpportunity(supporter, oldPledge, 100);
+        insert opp;
+            
+        Test.startTest();
+        Decimal oldPledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :oldPledge.Id].Received_Amount__c;
+        Decimal newPledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :newPledge.Id].Received_Amount__c;
+        opp.Funraise_Pledge__c = newPledge.Id;
+        update opp;
+        Decimal oppOriginalAmount = opp.Amount;
+        opp.Amount = opp.Amount + 1;
+        update opp;
+        Decimal oldPledgeAmountAfter = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :oldPledge.Id].Received_Amount__c;
+        Decimal newPledgeAmountAfter = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :newPledge.Id].Received_Amount__c;
+        Test.stopTest();
+        
+        System.assertEquals(oppOriginalAmount, oldPledgeAmountBefore, 'The old pledge received amount should have been the amount of the opp that was originally to reference it');
+        System.assertEquals(null, newPledgeAmountBefore, 'The pledge received amount should have been null since there were no opps associated');
+        System.assertEquals(0, oldPledgeAmountAfter, 'The old pledge received amount should have been 0 since no opportunites are referencing it now');
+        System.assertEquals(opp.Amount, newPledgeAmountAfter, 'The new pledge received amount should have been the amount of the opp that was updated to reference it');
+    }
+    
+    static testMethod void existingOpp_delete() {  
+        Contact supporter = frDonorTest.getTestContact();
+        insert supporter;
+        Pledge__c pledge = createPledge(supporter);
+        insert pledge;
+        
+        Opportunity opp = createClosedOpportunity(supporter, pledge, 100);
+        insert opp;
+            
+        Test.startTest();
+        Decimal pledgeAmountBefore = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :pledge.Id].Received_Amount__c;
+        delete opp;
+        Decimal pledgeAmountAfter = [SELECT Received_Amount__c FROM Pledge__c WHERE Id = :pledge.Id].Received_Amount__c;
+        Test.stopTest();
+        
+        System.assertEquals(opp.Amount, pledgeAmountBefore, 'The pledge received amount should have been the opp amount that is associated');
+        System.assertEquals(0, pledgeAmountAfter, 'The pledge received amount should have been 0 since the only oppo fulfilling it was deleted');
+    }
+    
+    static Opportunity createClosedOpportunity(Contact supporter, Pledge__c pledge, Decimal amount) {
+		Opportunity opp = frDonationTest.getTestOpp();
+        OpportunityStage closedWonOppStage = [SELECT Id, ApiName FROM 
+                                              OpportunityStage WHERE IsWon = true AND IsClosed = true
+                                              AND IsActive = true];
+        opp.StageName = closedWonOppStage.ApiName;
+        opp.fr_Donor__c = supporter.Id;
+        opp.Funraise_Pledge__c = pledge != null ? pledge.Id : null;
+        opp.Amount = amount;
+        return opp;
+    }
+    
+    static Pledge__c createPledge(Contact supporter) {
+        return new Pledge__c(
+        	Name = 'Unit Test Pledge',
+            Supporter__c = supporter.Id,
+            Pledge_Amount__c = 100
+        );
+    }
+}

--- a/src/classes/frOpportunityPledgeCalculatorTriggerTest.cls-meta.xml
+++ b/src/classes/frOpportunityPledgeCalculatorTriggerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frPledge.cls
+++ b/src/classes/frPledge.cls
@@ -1,0 +1,88 @@
+/*
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:  A class for representing a Funraise pledge.  Used for creating & matching to pledges
+*
+*
+*
+* CREATED: 2020 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
+public class frPledge {
+    public static Pledge__c findActive(Id contactId) {
+        List<Pledge__c> activePledges = [SELECT Id FROM Pledge__c 
+                                         WHERE Supporter__c = :contactId 
+                                         AND (Start_Date__c = null OR Start_Date__c >= TODAY)
+                                         AND (End_Date__c = null OR End_Date__c <= TODAY)
+                                         AND Active__c = true
+                                         AND Pledge_Donation__c = null
+                                         ORDER BY CreatedDate ASC LIMIT 1
+                                        ];
+        return activePledges.size() > 0 ? activePledges.get(0) : null;
+    }
+    
+    public static Pledge__c create(Opportunity opp) {
+        Pledge__c pledge = new Pledge__c(
+            Name = frUtil.truncateToFieldLength(Pledge__c.Name.getDescribe(), opp.Name + ' Pledge'),
+            Supporter__c = opp.fr_Donor__c,
+            Pledge_Amount__c = opp.Amount,
+            Pledge_Donation__c = opp.Id,
+            Pledge_Donation_uq__c = opp.Id
+        );
+        try {
+            Database.upsert(pledge, Pledge__c.Pledge_Donation_uq__c , true);
+            opp.Funraise_Pledge__c = pledge.Id;
+            update opp;
+        } catch (Exception ex) {
+            frUtil.logException(frUtil.Entity.PLEDGE, opp.fr_Id__c, ex);
+        }
+        
+        return pledge;
+    }
+    
+    public static Pledge__c create(Subscription__c subscription, Decimal pledgeAmount) {
+        Pledge__c pledge = new Pledge__c(
+            Name = frUtil.truncateToFieldLength(Pledge__c.Name.getDescribe(), 'Subscription Pledge - ' + subscription.Name),
+            Supporter__c = subscription.Supporter__c,
+            Pledge_Amount__c = pledgeAmount,
+            Pledge_Subscription__c = subscription.Id,
+            Pledge_Subscription_uq__c = subscription.Id
+        );
+        try {
+            Database.upsert(pledge, Pledge__c.Pledge_Subscription_uq__c , true);
+        } catch (Exception ex) {
+            frUtil.logException(frUtil.Entity.PLEDGE, subscription.fr_Id__c, ex);
+        }
+        
+        return pledge;
+    }
+}

--- a/src/classes/frPledge.cls-meta.xml
+++ b/src/classes/frPledge.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frSubscription.cls
+++ b/src/classes/frSubscription.cls
@@ -94,6 +94,9 @@ public class frSubscription {
         request.remove('supporterId');
         request.remove('campaignGoalId');
         request.remove('deleted');
+        String strPledgeAmount = String.valueOf(request.get('pledgeAmount'));
+        Decimal pledgeAmount = String.isNotBlank(strPledgeAmount) ? Decimal.valueOf(strPledgeAmount) : null;
+        request.remove('pledgeAmount');
         
         String regex = '([a-z])([A-Z]+)';
         String replacement = '$1_$2';
@@ -109,6 +112,10 @@ public class frSubscription {
         } catch (DMLException ex) {
             frUtil.logException(frUtil.Entity.SUBSCRIPTION, funraiseId, ex);
             return;
+        }
+        
+        if(pledgeAmount != null) {
+            frPledge.create(subscription, pledgeAmount);
         }
     }
     

--- a/src/classes/frSubscriptionTest.cls
+++ b/src/classes/frSubscriptionTest.cls
@@ -188,6 +188,38 @@ public class frSubscriptionTest {
         System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
     }
     
+    static testMethod void createSubscription_createPledge() {
+        Contact testSupporter = frDonorTest.getTestContact();
+        insert testSupporter;
+                
+        String funraiseId = '25';
+        Map<String, Object> request = getTestRequest();
+        request.put('supporterId', testSupporter.fr_ID__c);
+        request.put('id', funraiseId);
+        request.put('pledgeAmount', 500);
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+        Test.startTest();
+
+        frWSSubscriptionController.syncEntity();
+
+        Test.stopTest();
+        
+        Subscription__c subscription = [SELECT Id, Supporter__c FROM Subscription__c WHERE fr_ID__c = :funraiseId];
+        System.assertEquals(testSupporter.Id, subscription.Supporter__c, 'The lookup for supporter should have been populated with the contact that has the funraise id referenced in the request');
+        System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
+		Pledge__c pledge = [SELECT Id, Pledge_Amount__c, Supporter__c FROM Pledge__c WHERE Pledge_Subscription__c = :subscription.Id];
+        System.assertEquals(testSupporter.Id, pledge.Supporter__c, 'The pledge should have been created with the same supporter as the subscription');
+        System.assertEquals(500, pledge.Pledge_Amount__c, 'The pledge amount should have been what was received in the request');
+    }
+    
     private static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('name', '000001');
@@ -216,6 +248,7 @@ public class frSubscriptionTest {
         request.put('operationsTip', true);
         request.put('imported', false);
         request.put('deleted', false);
+        request.put('pledgeAmount', null);
         return request;
     }
     

--- a/src/classes/frUtil.cls
+++ b/src/classes/frUtil.cls
@@ -1,4 +1,5 @@
 public class frUtil {
+    private static String FUNRAISE_ID_FIELD = 'fr_Id__c';
     public static String truncateToFieldLength(DescribeFieldResult describe, String value) { 
         return String.isNotBlank(value) && value.length() > describe.getLength() ? value.substring(0, describe.getLength()) : value;
     }
@@ -95,8 +96,22 @@ public class frUtil {
         logError(errObject, recordId, error);
     }
     
+    private static Set<StatusCode> duplicateValueStatusCodes = 
+        new Set<StatusCode>{StatusCode.DUPLICATE_EXTERNAL_ID, StatusCode.DUPLICATE_VALUE};
+            
     public static void logException(Entity errObject, String recordId, Exception ex) {
-        logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());
+        if(ex instanceof DMLException) {
+            DMLException dmlEx = (DMLException)ex;
+            //If it's the race condition on fr_Id__c duplicate value, then ignore it.  Else, log it
+            for(Integer i = 0; i < dmlEx.getNumDml(); i++) {
+                if(!(dmlEx.getDmlMessage(i).containsIgnoreCase(FUNRAISE_ID_FIELD) && duplicateValueStatusCodes.contains(dmlEx.getDmlType(i)))) {
+                    logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());
+                }
+            }
+            
+        } else {
+            logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());            
+        }
     }
     
     public static void logError(Entity errObject, String recordId, String error) {
@@ -126,6 +141,8 @@ public class frUtil {
             funraiseObject = 'Email';
         } else if (frObject == Entity.TASK) {
             funraiseObject = 'Task/Interaction';
+        } else if (frObject == Entity.PLEDGE) {
+            funraiseObject = 'Pledge';
         }
         return funraiseObject;
     }
@@ -138,7 +155,8 @@ public class frUtil {
         SUBSCRIPTION,
         CAMPAIGN,
         EMAIL,
-        TASK
+        TASK,
+        PLEDGE
     }
     
 }

--- a/src/objects/Error__c.object
+++ b/src/objects/Error__c.object
@@ -126,6 +126,11 @@
                     <default>false</default>
                     <label>Task/Interaction</label>
                 </value>
+                <value>
+                    <fullName>Pledge</fullName>
+                    <default>false</default>
+                    <label>Pledge</label>
+                </value>
             </valueSetDefinition>
         </valueSet>
     </fields>

--- a/src/objects/Opportunity.object
+++ b/src/objects/Opportunity.object
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <fields>
+        <fullName>Funraise_Pledge__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <description>The Funraise pledge this opportunity should count towards</description>
+        <externalId>false</externalId>
+        <label>Funraise Pledge</label>
+        <referenceTo>Pledge__c</referenceTo>
+        <relationshipLabel>Opportunities</relationshipLabel>
+        <relationshipName>Opportunities</relationshipName>
+        <required>false</required>
+        <trackFeedHistory>false</trackFeedHistory>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
+    <fields>
         <fullName>Subscription__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
         <deprecated>false</deprecated>

--- a/src/objects/Pledge__c.object
+++ b/src/objects/Pledge__c.object
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <actionOverrides>
+        <actionName>Accept</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>CancelEdit</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Clone</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Delete</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Edit</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>List</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>New</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>SaveEdit</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Tab</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>View</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <allowInChatterGroups>false</allowInChatterGroups>
+    <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableChangeDataCapture>false</enableChangeDataCapture>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>false</enableHistory>
+    <enableReports>false</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <fields>
+        <fullName>Active__c</fullName>
+        <description>A checkbox formula field that denotes if the pledged amount has been met or exceeded and that the StartDate is after today and EndDate is before today</description>
+        <externalId>false</externalId>
+        <formula>(ISBLANK(Received_Amount__c) || Received_Amount__c &lt;= Pledge_Amount__c)
+&amp;&amp;
+(ISBLANK(Start_Date__c) || Start_Date__c &gt;= TODAY())
+&amp;&amp; 
+(ISBLANK(End_Date__c) || End_Date__c &lt;= TODAY())</formula>
+        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+        <inlineHelpText>A checkbox formula field that denotes if the pledged amount has been met or exceeded and that the StartDate is after today and EndDate is before today</inlineHelpText>
+        <label>Is Active</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
+        <fullName>End_Date__c</fullName>
+        <description>The date on which this pledge should be considered inactive and donations will stop automatically counting towards fulfilling it</description>
+        <externalId>false</externalId>
+        <label>End Date</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Date</type>
+    </fields>
+    <fields>
+        <fullName>Percent_Complete__c</fullName>
+        <externalId>false</externalId>
+        <formula>Received_Amount__c/Pledge_Amount__c</formula>
+        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+        <label>Percent Complete</label>
+        <precision>18</precision>
+        <required>false</required>
+        <scale>2</scale>
+        <trackTrending>false</trackTrending>
+        <type>Percent</type>
+    </fields>
+    <fields>
+        <fullName>Pledge_Amount__c</fullName>
+        <description>The total amount for this pledge</description>
+        <externalId>false</externalId>
+        <label>Pledge Amount</label>
+        <precision>18</precision>
+        <required>true</required>
+        <scale>2</scale>
+        <trackTrending>false</trackTrending>
+        <type>Currency</type>
+    </fields>
+    <fields>
+        <fullName>Pledge_Donation__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <description>Note: This field will only be filled out for pledges that are created directly from Funraise.  These pledges don&apos;t get fulfilled by multiple donations, only a single donation represented by this lookup field</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Note: This field will only be filled out for pledges that are created directly from Funraise.  These pledges don&apos;t get fulfilled by multiple donations, only a single donation represented by this lookup field</inlineHelpText>
+        <label>Pledge Donation</label>
+        <referenceTo>Opportunity</referenceTo>
+        <relationshipLabel>Funraise Pledges</relationshipLabel>
+        <relationshipName>Funraise_Pledges</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
+    <fields>
+        <fullName>Pledge_Donation_uq__c</fullName>
+        <caseSensitive>false</caseSensitive>
+        <description>Only one pledge may reference an given opportunity as it&apos;s sole pledge donation.  This field enforces that since we can&apos;t make the lookup field unique</description>
+        <externalId>true</externalId>
+        <label>Pledge Donation (unique)</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>true</unique>
+    </fields>
+    <fields>
+        <fullName>Pledge_Subscription__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <description>The subscription that created this pledge</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The subscription that created this pledge</inlineHelpText>
+        <label>Pledge Subscription</label>
+        <referenceTo>Subscription__c</referenceTo>
+        <relationshipLabel>Funraise Pledges</relationshipLabel>
+        <relationshipName>Funraise_Pledges</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
+    <fields>
+        <fullName>Pledge_Subscription_uq__c</fullName>
+        <caseSensitive>false</caseSensitive>
+        <externalId>true</externalId>
+        <label>Pledge Subscription (unique)</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>true</unique>
+    </fields>
+    <fields>
+        <fullName>Received_Amount__c</fullName>
+        <description>Summed opportunity amounts related to this pledge.  Calculation of this value is handled by a trigger whenever opportunities related to this pledge are added or updated</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Calculation of this value is handled by a trigger whenever opportunities related to this pledge are added or updated</inlineHelpText>
+        <label>Received Amount</label>
+        <precision>18</precision>
+        <required>false</required>
+        <scale>2</scale>
+        <trackTrending>false</trackTrending>
+        <type>Currency</type>
+    </fields>
+    <fields>
+        <fullName>Start_Date__c</fullName>
+        <description>The date at which this pledge should be considered active and have donations automatically count towards fulfilling the pledge</description>
+        <externalId>false</externalId>
+        <label>Start Date</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Date</type>
+    </fields>
+    <fields>
+        <fullName>Supporter__c</fullName>
+        <description>The contact that represents the Funraise supporter that owns this pledge</description>
+        <externalId>false</externalId>
+        <label>Funraise Supporter</label>
+        <referenceTo>Contact</referenceTo>
+        <relationshipLabel>Funraise Pledges</relationshipLabel>
+        <relationshipName>Funraise_Pledges</relationshipName>
+        <relationshipOrder>0</relationshipOrder>
+        <reparentableMasterDetail>false</reparentableMasterDetail>
+        <trackTrending>false</trackTrending>
+        <type>MasterDetail</type>
+        <writeRequiresMasterRead>false</writeRequiresMasterRead>
+    </fields>
+    <label>Funraise Pledge</label>
+    <listViews>
+        <fullName>All</fullName>
+        <filterScope>Everything</filterScope>
+        <label>All</label>
+    </listViews>
+    <nameField>
+        <label>Funraise Pledge Name</label>
+        <type>Text</type>
+    </nameField>
+    <pluralLabel>Funraise Pledges</pluralLabel>
+    <searchLayouts/>
+    <sharingModel>ControlledByParent</sharingModel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/src/objects/Pledge__c.object
+++ b/src/objects/Pledge__c.object
@@ -56,11 +56,11 @@
         <fullName>Active__c</fullName>
         <description>A checkbox formula field that denotes if the pledged amount has been met or exceeded and that the StartDate is after today and EndDate is before today</description>
         <externalId>false</externalId>
-        <formula>(ISBLANK(Received_Amount__c) || Received_Amount__c &lt;= Pledge_Amount__c)
+        <formula>(ISBLANK(Received_Amount__c) || Received_Amount__c &lt; Pledge_Amount__c)
 &amp;&amp;
-(ISBLANK(Start_Date__c) || Start_Date__c &gt;= TODAY())
+(ISBLANK(Start_Date__c) || Start_Date__c &lt;= TODAY())
 &amp;&amp; 
-(ISBLANK(End_Date__c) || End_Date__c &lt;= TODAY())</formula>
+(ISBLANK(End_Date__c) || End_Date__c &gt;= TODAY())</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
         <inlineHelpText>A checkbox formula field that denotes if the pledged amount has been met or exceeded and that the StartDate is after today and EndDate is before today</inlineHelpText>
         <label>Is Active</label>

--- a/src/package.xml
+++ b/src/package.xml
@@ -16,6 +16,7 @@
         <members>frFundraisingEventTest</members>
         <members>frModel</members>
         <members>frOpportunityPledgeCalculatorTriggerTest</members>
+        <members>frPledge</members>
         <members>frSchemaUtil</members>
         <members>frSetupController</members>
         <members>frSetupControllerTest</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -15,6 +15,7 @@
         <members>frFundraisingEventRegistrationTest</members>
         <members>frFundraisingEventTest</members>
         <members>frModel</members>
+        <members>frOpportunityPledgeCalculatorTriggerTest</members>
         <members>frSchemaUtil</members>
         <members>frSetupController</members>
         <members>frSetupControllerTest</members>
@@ -37,6 +38,10 @@
         <name>ApexPage</name>
     </types>
     <types>
+        <members>frOpportunityPledgeCalculator</members>
+        <name>ApexTrigger</name>
+    </types>
+    <types>
         <members>Funraise</members>
         <name>CustomApplication</name>
     </types>
@@ -45,6 +50,7 @@
         <members>Campaign.fr_ID__c</members>
         <members>Contact.fr_ID__c</members>
         <members>EmailMessage.fr_Email_ID__c</members>
+        <members>Opportunity.Funraise_Pledge__c</members>
         <members>Opportunity.Subscription__c</members>
         <members>Opportunity.fr_Donor__c</members>
         <members>Opportunity.fr_ID__c</members>
@@ -58,6 +64,7 @@
         <members>Error__c</members>
         <members>Fundraising_Event_Registration__c</members>
         <members>Fundraising_Event__c</members>
+        <members>Pledge__c</members>
         <members>Subscription__c</members>
         <members>frField__mdt</members>
         <members>frMapping__c</members>
@@ -68,12 +75,17 @@
         <members>Fundraising_Event_Registration__c</members>
         <members>Fundraising_Event__c</members>
         <members>Funraise_Setup</members>
+        <members>Pledge__c</members>
         <members>Subscription__c</members>
         <name>CustomTab</name>
     </types>
     <types>
         <members>Funraise_Permission_Set</members>
         <name>PermissionSet</name>
+    </types>
+    <types>
+        <members>Pledge__c</members>
+        <name>Workflow</name>
     </types>
     <version>43.0</version>
 </Package>

--- a/src/permissionsets/Funraise_Permission_Set.permissionset
+++ b/src/permissionsets/Funraise_Permission_Set.permissionset
@@ -153,58 +153,63 @@
         <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event_Registration__c.Attended__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event_Registration__c.Guest_Of__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event_Registration__c.Ticket_Amount__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event_Registration__c.Ticket_Name__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event_Registration__c.Ticket_Tax_Deductible_Amount__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event_Registration__c.Transaction__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event_Registration__c.fr_ID__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event__c.Description__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event__c.End_Date__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Fundraising_Event__c.Start_Date__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
         <field>Fundraising_Event__c.fr_ID__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Opportunity.Funraise_Pledge__c</field>
         <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -224,128 +229,173 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Pledge__c.Active__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.End_Date__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.Percent_Complete__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.Pledge_Donation__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.Pledge_Donation_uq__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.Pledge_Subscription__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.Pledge_Subscription_uq__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.Received_Amount__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Pledge__c.Start_Date__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Subscription__c.Allocation_Name__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Amount__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Campaign_Goal__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Campaign_Page_Name__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Comment__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Company_Match_Company_Name__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Company_Match_Employee_Email__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Company_Match__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Currency__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Dedication_Email__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Dedication_Message__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Dedication_Name__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Dedication_Type__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Dedication__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Form_Name__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Frequency__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Imported__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Next_Payment_Date__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Note__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Operations_Tip__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Payment_Method_Expiration_Date__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Payment_Method_Last_Four__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Payment_Method_Type__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.Status__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Subscription__c.fr_ID__c</field>
-        <readable>false</readable>
+        <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>

--- a/src/tabs/Pledge__c.tab
+++ b/src/tabs/Pledge__c.tab
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customObject>true</customObject>
+    <mobileReady>false</mobileReady>
+    <motif>Custom25: Alarm clock</motif>
+</CustomTab>

--- a/src/triggers/frOpportunityPledgeCalculator.trigger
+++ b/src/triggers/frOpportunityPledgeCalculator.trigger
@@ -1,46 +1,46 @@
 /*
- *
- *  Copyright (c) 2020, Funraise Inc
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *  1. Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *  3. All advertising materials mentioning features or use of this software
- *     must display the following acknowledgement:
- *     This product includes software developed by the <organization>.
- *  4. Neither the name of the <organization> nor the
- *     names of its contributors may be used to endorse or promote products
- *     derived from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
- *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
- *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *
- *
- * PURPOSE:  A trigger on opportunity to update pledges they are related to with a pledge total
- *
- *
- *
- * CREATED: 2020 Funraise Inc - https://funraise.io
- * AUTHOR: Alex Molina
- */
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:  A trigger on opportunity to update pledges they are related to with a pledge total
+*
+*
+*
+* CREATED: 2020 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
 trigger frOpportunityPledgeCalculator on Opportunity (after insert, after update, after delete) {
     Set<Id> pledgeIds = new Set<Id>();
     if(Trigger.isInsert) {
-    	for(Opportunity opp : Trigger.new) {
+        for(Opportunity opp : Trigger.new) {
             if(opp.Funraise_Pledge__c != null) {
                 pledgeIds.add(opp.Funraise_Pledge__c);
             }
@@ -58,9 +58,9 @@ trigger frOpportunityPledgeCalculator on Opportunity (after insert, after update
                 }
             } else if (opp.Funraise_Pledge__c != null && 
                        (opp.Amount != oldOpp.Amount || opp.StageName != oldOpp.StageName)) {
-                pledgeIds.add(opp.Funraise_Pledge__c);
-            }
-
+                           pledgeIds.add(opp.Funraise_Pledge__c);
+                       }
+            
         }
         
     } else if (Trigger.isDelete) {
@@ -71,9 +71,9 @@ trigger frOpportunityPledgeCalculator on Opportunity (after insert, after update
         }
         
     }
-
+    
     if(pledgeIds.size() > 0) {
-		List<OpportunityStage> closedWonOppStages = [SELECT Id, ApiName FROM OpportunityStage WHERE IsWon = true AND IsClosed = true];
+        List<OpportunityStage> closedWonOppStages = [SELECT Id, ApiName FROM OpportunityStage WHERE IsWon = true AND IsClosed = true];
         Set<String> closedWonOppStageApiNames = new Set<String>();
         for(OpportunityStage oppStage : closedWonOppStages) {
             closedWonOppStageApiNames.add(oppStage.ApiName);
@@ -84,9 +84,9 @@ trigger frOpportunityPledgeCalculator on Opportunity (after insert, after update
                                               AND StageName IN :closedWonOppStageApiNames
                                               AND Funraise_Pledge__c IN :pledgeIds
                                               GROUP BY Funraise_Pledge__c];
-		Map<Id, Decimal> pledgeIdToTotal = new Map<Id, Decimal>();
+        Map<Id, Decimal> pledgeIdToTotal = new Map<Id, Decimal>();
         for(AggregateResult aggRes : pledgeAggregates) {
-        	pledgeIdToTotal.put(
+            pledgeIdToTotal.put(
                 (Id)aggRes.get('funraise__Funraise_Pledge__c'),
                 (Decimal)aggRes.get('amt')
             );
@@ -95,7 +95,7 @@ trigger frOpportunityPledgeCalculator on Opportunity (after insert, after update
         List<Pledge__c> pledgesToUpdate = new List<Pledge__c>();
         for(Id pledgeId : pledgeIds) {
             Pledge__c pledge = new Pledge__c(
-            	Id = pledgeId,
+                Id = pledgeId,
                 Received_Amount__c = pledgeIdToTotal.containsKey(pledgeId) ? pledgeIdToTotal.get(pledgeId) : 0
             );
             pledgesToUpdate.add(pledge);

--- a/src/triggers/frOpportunityPledgeCalculator.trigger
+++ b/src/triggers/frOpportunityPledgeCalculator.trigger
@@ -1,0 +1,106 @@
+/*
+ *
+ *  Copyright (c) 2020, Funraise Inc
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. All advertising materials mentioning features or use of this software
+ *     must display the following acknowledgement:
+ *     This product includes software developed by the <organization>.
+ *  4. Neither the name of the <organization> nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ * PURPOSE:  A trigger on opportunity to update pledges they are related to with a pledge total
+ *
+ *
+ *
+ * CREATED: 2020 Funraise Inc - https://funraise.io
+ * AUTHOR: Alex Molina
+ */
+trigger frOpportunityPledgeCalculator on Opportunity (after insert, after update, after delete) {
+    Set<Id> pledgeIds = new Set<Id>();
+    if(Trigger.isInsert) {
+    	for(Opportunity opp : Trigger.new) {
+            if(opp.Funraise_Pledge__c != null) {
+                pledgeIds.add(opp.Funraise_Pledge__c);
+            }
+        }
+    } else if (Trigger.IsUpdate) {
+        //only calculate if any of the values we care about changed here
+        for(Opportunity opp : Trigger.new) {
+            Opportunity oldOpp = Trigger.oldMap.get(opp.Id);
+            if(opp.Funraise_Pledge__c != oldOpp.Funraise_Pledge__c) {
+                if(opp.Funraise_Pledge__c != null) {
+                    pledgeIds.add(opp.Funraise_Pledge__c);                    
+                }
+                if(oldOpp.Funraise_Pledge__c != null) {
+                    pledgeIds.add(oldOpp.Funraise_Pledge__c);
+                }
+            } else if (opp.Funraise_Pledge__c != null && 
+                       (opp.Amount != oldOpp.Amount || opp.StageName != oldOpp.StageName)) {
+                pledgeIds.add(opp.Funraise_Pledge__c);
+            }
+
+        }
+        
+    } else if (Trigger.isDelete) {
+        for(Opportunity opp : Trigger.old) {
+            if(opp.Funraise_Pledge__c != null) {
+                pledgeIds.add(opp.Funraise_Pledge__c);
+            }
+        }
+        
+    }
+
+    if(pledgeIds.size() > 0) {
+		List<OpportunityStage> closedWonOppStages = [SELECT Id, ApiName FROM OpportunityStage WHERE IsWon = true AND IsClosed = true];
+        Set<String> closedWonOppStageApiNames = new Set<String>();
+        for(OpportunityStage oppStage : closedWonOppStages) {
+            closedWonOppStageApiNames.add(oppStage.ApiName);
+        }
+        
+        AggregateResult[] pledgeAggregates = [SELECT funraise__Funraise_Pledge__c, SUM(amount)amt FROM Opportunity 
+                                              WHERE amount != null 
+                                              AND StageName IN :closedWonOppStageApiNames
+                                              AND Funraise_Pledge__c IN :pledgeIds
+                                              GROUP BY Funraise_Pledge__c];
+		Map<Id, Decimal> pledgeIdToTotal = new Map<Id, Decimal>();
+        for(AggregateResult aggRes : pledgeAggregates) {
+        	pledgeIdToTotal.put(
+                (Id)aggRes.get('funraise__Funraise_Pledge__c'),
+                (Decimal)aggRes.get('amt')
+            );
+        }
+        
+        List<Pledge__c> pledgesToUpdate = new List<Pledge__c>();
+        for(Id pledgeId : pledgeIds) {
+            Pledge__c pledge = new Pledge__c(
+            	Id = pledgeId,
+                Received_Amount__c = pledgeIdToTotal.containsKey(pledgeId) ? pledgeIdToTotal.get(pledgeId) : 0
+            );
+            pledgesToUpdate.add(pledge);
+        }
+        update pledgesToUpdate;
+    }
+    
+}

--- a/src/triggers/frOpportunityPledgeCalculator.trigger-meta.xml
+++ b/src/triggers/frOpportunityPledgeCalculator.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/src/workflows/Pledge__c.workflow
+++ b/src/workflows/Pledge__c.workflow
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workflow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fieldUpdates>
+        <fullName>Sync_Pledge_donation_fields</fullName>
+        <description>See workflow description</description>
+        <field>Pledge_Donation_uq__c</field>
+        <formula>Pledge_Donation__c</formula>
+        <name>Sync Pledge donation fields</name>
+        <notifyAssignee>false</notifyAssignee>
+        <operation>Formula</operation>
+        <protected>false</protected>
+    </fieldUpdates>
+    <fieldUpdates>
+        <fullName>Sync_Pledge_subscription_fields</fullName>
+        <field>Pledge_Subscription_uq__c</field>
+        <formula>Pledge_Subscription__c</formula>
+        <name>Sync Pledge subscription fields</name>
+        <notifyAssignee>false</notifyAssignee>
+        <operation>Formula</operation>
+        <protected>false</protected>
+    </fieldUpdates>
+    <rules>
+        <fullName>Sync Pledge fields</fullName>
+        <actions>
+            <name>Sync_Pledge_donation_fields</name>
+            <type>FieldUpdate</type>
+        </actions>
+        <actions>
+            <name>Sync_Pledge_subscription_fields</name>
+            <type>FieldUpdate</type>
+        </actions>
+        <active>true</active>
+        <description>There are 2 fields for each relationship.  One is a lookup, another is an external id field used for database operations (unique, upserting). This workflow rule will keep them in sync</description>
+        <formula>(Pledge_Donation__c &lt;&gt; Pledge_Donation_uq__c) ||
+(Pledge_Subscription__c &lt;&gt;
+ Pledge_Subscription_uq__c )</formula>
+        <triggerType>onCreateOrTriggeringUpdate</triggerType>
+    </rules>
+</Workflow>


### PR DESCRIPTION
A pledge can be manually created in Salesforce or automatically created from Funraise.  Once the pledge exists for a supporter, then donations from that supporter will count towards the pledge (start date & end date will constrain this).
Resolving FUN-9202