### PR TITLE
Adding fields + migration for registrations that are not connected to supporters

### DIFF
--- a/src/classes/frDataMigration.cls
+++ b/src/classes/frDataMigration.cls
@@ -1,0 +1,58 @@
+/*
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE: A class to migrate data between releases of the Salesforce managed package.  
+* 	primarily in cases where one field is being replaced by another and we need to copy data.
+*
+*
+* CREATED: 2020 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
+public class frDataMigration implements InstallHandler {
+    public void onInstall(InstallContext context) {
+        migrateRegistration_masterDetail_to_lookup();
+    }
+    
+    private void migrateRegistration_masterDetail_to_lookup() {
+        if([SELECT COUNT() FROM Fundraising_Event_Registration__c WHERE Supporter__c != null AND Registrant__c = null] > 0) {
+            List<Fundraising_Event_Registration__c> records = [SELECT Id, Supporter__c, Registrant__c 
+                                                               FROM Fundraising_Event_Registration__c
+                                                               WHERE Supporter__c != null AND Registrant__c = null
+                                                              ];
+            for(Fundraising_Event_Registration__c record : records) {
+                record.Registrant__c = record.Supporter__c;
+            }
+            update records;
+            
+        }
+    }
+}

--- a/src/classes/frDataMigration.cls-meta.xml
+++ b/src/classes/frDataMigration.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frDataMigrationTest.cls
+++ b/src/classes/frDataMigrationTest.cls
@@ -1,0 +1,68 @@
+/*
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE: Test class for migration class used for post-package-install execution
+*
+*
+* CREATED: 2020 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
+@isTest
+public class frDataMigrationTest {
+    @isTest
+    static void testRegistrationLookupMigration() {
+        Fundraising_Event__c testEvent = frFundraisingEventTest.getTestEvent();
+        insert testEvent;
+        
+        Contact testSupporter = frDonorTest.getTestContact();
+        insert testSupporter;
+        
+        Fundraising_Event_Registration__c registration = new Fundraising_Event_Registration__c(
+            Attended__c = false,
+            Fundraising_Event__c = testEvent.Id,
+            fr_Id__c = '1234',
+            Guest_Of__c = testSupporter.Id,
+            Supporter__c = testSupporter.Id,
+            Ticket_Name__c = 'Test Ticket'
+        );
+        insert registration;
+        
+        Test.startTest();
+        new frDataMigration().onInstall(null);
+        Test.stopTest();
+        
+        Fundraising_Event_Registration__c requeryRegistration = [SELECT Id, Registrant__c FROM Fundraising_Event_Registration__c
+                                                                WHERE Id = :registration.Id];
+        System.assertEquals(registration.Supporter__c, requeryRegistration.Registrant__c, 'The contact id from the master-detail relationship was not copied properly to the lookup field');
+        
+    }
+}

--- a/src/classes/frDataMigrationTest.cls-meta.xml
+++ b/src/classes/frDataMigrationTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frFundraisingEventRegistration.cls
+++ b/src/classes/frFundraisingEventRegistration.cls
@@ -66,12 +66,16 @@ public class frFundraisingEventRegistration {
         }
         
         String funraiseSupporterId = String.valueOf(request.get('supporterId'));
-        List<Contact> supporter = [SELECT Id from Contact WHERE fr_Id__c = :funraiseSupporterId];
-        if(supporter.isEmpty()) {
-            frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
-                                        frUtil.Entity.SUPPORTER, funraiseSupporterId,
-                                       'Registration supporter, not guest of');
-            return;
+        List<Contact> supporter = new List<Contact>();
+        if(String.isNotBlank(funraiseSupporterId)) {
+            supporter = [SELECT Id from Contact WHERE fr_Id__c = :funraiseSupporterId];
+            if(supporter.isEmpty()) {
+                //if it wasn't found, log an error but continue
+                frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
+                                            frUtil.Entity.SUPPORTER, funraiseSupporterId,
+                                            'Registration registrant');
+                return; //TODO: remove this early return once the master-detail field is replaced with the lookup
+            }
         }
         
         String funraiseGuestOfId = String.valueOf(request.get('guestOfId'));
@@ -111,9 +115,26 @@ public class frFundraisingEventRegistration {
             ),
             Attended__c = Boolean.valueOf(request.get('attended')),
             Fundraising_Event__c = event.get(0).Id,
-            Supporter__c = supporter.get(0).Id,
+            Supporter__c = supporter.isEmpty() ?  null : supporter.get(0).Id, //TODO: Remove this line once we remove the master-detail field
+            Registrant__c = supporter.isEmpty() ?  null : supporter.get(0).Id,
             Guest_Of__c = guestOf.isEmpty() ?  null : guestOf.get(0).Id,
-            Transaction__c = transactions.isEmpty() ? null : transactions.get(0).Id
+            Transaction__c = transactions.isEmpty() ? null : transactions.get(0).Id,
+            First_Name__c = frUtil.truncateToFieldLength(
+                Fundraising_Event_Registration__c.First_Name__c.getDescribe(), 
+                String.valueOf(request.get('firstName'))
+            ),
+            Last_Name__c = frUtil.truncateToFieldLength(
+                Fundraising_Event_Registration__c.Last_Name__c.getDescribe(), 
+                String.valueOf(request.get('lastName'))
+            ),
+            Phone__c = frUtil.truncateToFieldLength(
+                Fundraising_Event_Registration__c.Phone__c.getDescribe(), 
+                String.valueOf(request.get('phone'))
+            ),
+            Email__c = frUtil.truncateToFieldLength(
+                Fundraising_Event_Registration__c.Email__c.getDescribe(), 
+                String.valueOf(request.get('email'))
+            )
         );
         frUtil.write(
             registration, 

--- a/src/classes/frFundraisingEventRegistrationTest.cls
+++ b/src/classes/frFundraisingEventRegistrationTest.cls
@@ -79,7 +79,8 @@ public class frFundraisingEventRegistrationTest {
         Fundraising_Event_Registration__c registration = [SELECT Id, fr_ID__c, Name, Attended__c, Ticket_Name__c, Ticket_Amount__c,
                                                           Ticket_Tax_Deductible_Amount__c,
                                                           Supporter__c, Fundraising_Event__c, 
-                                                          Guest_Of__c, Transaction__c
+                                                          Guest_Of__c, Transaction__c, First_Name__c,
+                                                          Last_Name__c, Phone__c, Email__c
                                                           FROM Fundraising_Event_Registration__c WHERE fr_ID__c = :funraiseId];
         
         System.assertEquals(String.valueOf(request.get('name')), registration.Name, 'The registration name should be the property included in the request');
@@ -91,6 +92,10 @@ public class frFundraisingEventRegistrationTest {
         System.assertEquals(testSupporter.Id, registration.Supporter__c, 'The lookup for supporter should have been populated with the contact that has the funraise id referenced in the request');
         System.assertEquals(testSupporter.Id, registration.Guest_Of__c, 'The lookup for guest of should have been populated with the contact that has the funraise id referenced in the request');
         System.assertEquals(testTransaction.Id, registration.Transaction__c, 'The lookup for transaction should have been populated with the opportunity that has the funraise id referenced in the request');
+        System.assertEquals(String.valueOf(request.get('firstName')), registration.First_Name__c, 'The first name should have been populated with the contact info first name in the request');
+        System.assertEquals(String.valueOf(request.get('lastName')), registration.Last_Name__c, 'The last name should have been populated with the contact info last name in the request');
+        System.assertEquals(String.valueOf(request.get('email')), registration.Email__c, 'The email should have been populated with the contact info email in the request');
+        System.assertEquals(String.valueOf(request.get('phone')), registration.Phone__c, 'The phone should have been populated with the contact info phone in the request');
     }
     
     static testMethod void createRegistration_eventMissing() {	
@@ -140,6 +145,8 @@ public class frFundraisingEventRegistrationTest {
                                                                  Supporter__c, Fundraising_Event__c, 
                                                                  Guest_Of__c 
                                                                  FROM Fundraising_Event_Registration__c WHERE fr_ID__c = :funraiseId];
+        //TODO: remove below assert and uncomment this one once it's valid (a.k.a the master-detail field is removed)
+        //System.assertEquals(1, registrations.size(), 'A registration should have been created even if a supporter id could not be matched'); 
         System.assertEquals(0, registrations.size(), 'No registrations should have been created if a supporter id could not be matched');
         System.assertEquals(0, errorsBefore, 'Precondition');
         System.assertEquals(1, errorsAfter, 'An error log should have been created to record that a supporter id could not be matched');
@@ -282,6 +289,10 @@ public class frFundraisingEventRegistrationTest {
         request.put('transactionId', null);
         request.put('id', 'changeme');
         request.put('deleted', false);
+        request.put('firstName', 'testFirstName');
+        request.put('lastName', 'testLastName');
+        request.put('email', 'test@example.com');
+        request.put('phone', '1234567890');
         return request;
     }
     

--- a/src/objects/Fundraising_Event_Registration__c.object
+++ b/src/objects/Fundraising_Event_Registration__c.object
@@ -63,6 +63,52 @@
         <type>Checkbox</type>
     </fields>
     <fields>
+        <fullName>Email_Display__c</fullName>
+        <externalId>false</externalId>
+        <formula>IF(ISBLANK(Registrant__c), 
+Email__c,
+Registrant__r.Email)</formula>
+        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+        <label>Email</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Email__c</fullName>
+        <externalId>false</externalId>
+        <label>Email</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>First_Name_Display__c</fullName>
+        <externalId>false</externalId>
+        <formula>IF(ISBLANK(Registrant__c), 
+First_Name__c,
+Registrant__r.FirstName)</formula>
+        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+        <label>First Name</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>First_Name__c</fullName>
+        <externalId>false</externalId>
+        <label>First Name</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Fundraising_Event__c</fullName>
         <deprecated>false</deprecated>
         <externalId>false</externalId>
@@ -85,6 +131,62 @@
         <referenceTo>Contact</referenceTo>
         <relationshipLabel>Funraise Event Registrations (Guest Of)</relationshipLabel>
         <relationshipName>Funraise_Event_Registrations1</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
+    <fields>
+        <fullName>Last_Name_Display__c</fullName>
+        <externalId>false</externalId>
+        <formula>IF(ISBLANK(Registrant__c), 
+Last_Name__c,
+Registrant__r.LastName)</formula>
+        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+        <label>Last Name</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Last_Name__c</fullName>
+        <externalId>false</externalId>
+        <label>Last Name</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Phone_Display__c</fullName>
+        <externalId>false</externalId>
+        <formula>IF(ISBLANK(Registrant__c), 
+Phone__c,
+Registrant__r.Phone)</formula>
+        <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+        <label>Phone</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Phone__c</fullName>
+        <externalId>false</externalId>
+        <label>Phone</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Phone</type>
+    </fields>
+    <fields>
+        <fullName>Registrant__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <externalId>false</externalId>
+        <label>Registrant</label>
+        <referenceTo>Contact</referenceTo>
+        <relationshipLabel>Funraise Event Registrations (Registrant)</relationshipLabel>
+        <relationshipName>Funraise_Event_Registrations2</relationshipName>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Lookup</type>

--- a/src/package.xml
+++ b/src/package.xml
@@ -3,6 +3,8 @@
     <types>
         <members>frCampaign</members>
         <members>frCampaignTest</members>
+        <members>frDataMigration</members>
+        <members>frDataMigrationTest</members>
         <members>frDonation</members>
         <members>frDonationTest</members>
         <members>frDonor</members>

--- a/src/permissionsets/Funraise_Permission_Set.permissionset
+++ b/src/permissionsets/Funraise_Permission_Set.permissionset
@@ -158,9 +158,54 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.Email_Display__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.Email__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.First_Name_Display__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.First_Name__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Fundraising_Event_Registration__c.Guest_Of__c</field>
         <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.Last_Name_Display__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.Last_Name__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.Phone_Display__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.Phone__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Fundraising_Event_Registration__c.Registrant__c</field>
+        <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>


### PR DESCRIPTION
Adding some preparation for accepting registrations that are not connected to a supporter.  This commit includes a migration that is tied to the managed package to be executed post-install

After this is deployed and old values are copied to the new lookup field (and all new records starting with this version), we will be able to delete the master-detail field to allow registrations to be created without a contact
Resolving FUN-7155