### PR TITLE
Adding infrastructure for retrying requests when they fail

### DIFF
--- a/src/classes/frAnswer.cls
+++ b/src/classes/frAnswer.cls
@@ -38,32 +38,44 @@
 * AUTHOR: Alex Molina
 */
 
-public class frAnswer {
-    public frAnswer(Map<String, Object> request) {
-        if (Boolean.valueOf(request.get('deleted'))) {
-            deleteAnswer(String.valueOf(request.get('id')));
-        } else {
-            create(request);
-        }
+public class frAnswer extends frModel implements frSyncable {
+    public frAnswer(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
     
-    public void deleteAnswer(String funraiseId) {
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+    	if (Boolean.valueOf(request.get('deleted'))) {
+            result = deleteAnswer(String.valueOf(request.get('id')));
+        } else {
+            result = create(request);
+        }
+        return result;
+    }
+    
+    private Boolean deleteAnswer(String funraiseId) {
+        Boolean result = false;
         try {
             delete [SELECT id FROM Answer__c WHERE fr_ID__c = :funraiseId];
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.ANSWER, funraiseId, e);
+            if(createLogRecord) frUtil.logException(frUtil.Entity.ANSWER, funraiseId, e);
         }
+        return result;
     }
     
-    public void create(Map<String, Object> request) {
+    private Boolean create(Map<String, Object> request) {
+        Boolean result = false;
         String funraiseId = String.valueOf(request.get('id'));
         
         String questionId = String.valueOf(request.get('questionId'));
         List<Question__c> questions = [SELECT Id from Question__c WHERE fr_Id__c = :questionId];
         if(questions.isEmpty()) {
-            frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
+            if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
                                         frUtil.Entity.QUESTION, questionId);
-            return;
+            return result;
         }
         
         Contact supporter = null;
@@ -71,7 +83,7 @@ public class frAnswer {
         if(String.isNotBlank(funraiseSupporterId)) {
             List<Contact> contacts = [SELECT Id from Contact WHERE fr_Id__c = :funraiseSupporterId];
             if(contacts.isEmpty()) {
-                frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
                                             frUtil.Entity.SUPPORTER, funraiseSupporterId);
             } else {
                 supporter = contacts.get(0);
@@ -83,7 +95,7 @@ public class frAnswer {
         if(String.isNotBlank(funraiseTransactionId)) {
             List<Opportunity> transactions = [SELECT Id from Opportunity WHERE fr_Id__c = :funraiseTransactionId];
             if(transactions.isEmpty()) {
-                frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
                                             frUtil.Entity.DONATION, funraiseTransactionId);
             } else {
                 opp = transactions.get(0);
@@ -95,7 +107,7 @@ public class frAnswer {
         if(String.isNotBlank(funraisePageGoalId)) {
             List<Campaign> pages = [SELECT Id from Campaign WHERE fr_Id__c = :funraisePageGoalId];
             if(pages.isEmpty()) {
-                frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
                                             frUtil.Entity.CAMPAIGN, funraisePageGoalId);
             } else {
                 page = pages.get(0);
@@ -107,7 +119,7 @@ public class frAnswer {
         if(String.isNotBlank(funraiseRegistrationId)) {
             List<Fundraising_Event_Registration__c> registrations = [SELECT Id from Fundraising_Event_Registration__c WHERE fr_Id__c = :funraiseRegistrationId];
             if(registrations.isEmpty()) {
-                frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.ANSWER, funraiseId, 
                                             frUtil.Entity.REGISTRATION, funraiseRegistrationId);
             } else {
                 registration = registrations.get(0);
@@ -129,9 +141,10 @@ public class frAnswer {
         
         try {
             Database.upsert(answer, Answer__c.Field.fr_ID__c, true);
+            result = true;
         } catch (DMLException ex) {
-            frUtil.logException(frUtil.Entity.ANSWER, funraiseId, ex);
-            return;
+            if(createLogRecord) frUtil.logException(frUtil.Entity.ANSWER, funraiseId, ex);
         }   
+        return result;
     } 
 }

--- a/src/classes/frAnswerTest.cls
+++ b/src/classes/frAnswerTest.cls
@@ -271,7 +271,7 @@ public class frAnswerTest {
         
         Test.stopTest();
         System.assertEquals(0, [SELECT COUNT() FROM Answer__c], 'Since the question relationship was missing, the answer should not have been created');
-        System.assertEquals(1, [SELECT COUNT() FROM Error__c], 'An error log should have been generated for the missing question');   
+        System.assertEquals(1, [SELECT COUNT() FROM Sync_Attempt__c], 'A sync attempt should have been generated because of the missing question');   
     }
     
     @isTest
@@ -304,10 +304,9 @@ public class frAnswerTest {
         
         Test.stopTest();
         System.assertEquals(1, [SELECT COUNT() FROM Answer__c], 'The required values were provided so the answer should exist');
-        System.assertEquals(4, [SELECT COUNT() FROM Error__c], 'An error log should have been generated for the missing relationships (supporter, opp, campaign, registration)');   
     }
     
-    private static Map<String, Object> getTestRequest() {
+    public static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', 1234);
         request.put('answer', 'Test answer');

--- a/src/classes/frAnswerTest.cls
+++ b/src/classes/frAnswerTest.cls
@@ -58,20 +58,13 @@ public class frAnswerTest {
         request.put('donationId', opp.fr_Id__c);
         request.put('supporterId', supporter.fr_Id__c);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question-answer';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         Test.startTest();
-        
         frWSCustomQuestionAnswerController.syncEntity();
-        
         Test.stopTest();
         frTestUtil.assertNoErrors();
+        
         Answer__c answer = [SELECT Id, fr_ID__c, Answer__c, Question__c, Transaction__c, Supporter__c
                             FROM Answer__c WHERE fr_ID__c = :funraiseId];
         
@@ -95,19 +88,12 @@ public class frAnswerTest {
         request.put('questionId', question.fr_Id__c);
         request.put('registrationId', registration.fr_Id__c);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question-answer';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         Test.startTest();
-        
         frWSCustomQuestionAnswerController.syncEntity();
-        
         Test.stopTest();
+        
         frTestUtil.assertNoErrors();
         Answer__c answer = [SELECT Id, fr_ID__c, Answer__c, Question__c, Registration__c
                             FROM Answer__c WHERE fr_ID__c = :funraiseId];
@@ -131,20 +117,13 @@ public class frAnswerTest {
         request.put('questionId', question.fr_Id__c);
         request.put('pageGoalId', campaign.fr_Id__c);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question-answer';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         Test.startTest();
-        
         frWSCustomQuestionAnswerController.syncEntity();
-        
         Test.stopTest();
         frTestUtil.assertNoErrors();
+        
         Answer__c answer = [SELECT Id, fr_ID__c, Answer__c, Question__c, Campaign_Page__c
                             FROM Answer__c WHERE fr_ID__c = :funraiseId];
         
@@ -180,20 +159,13 @@ public class frAnswerTest {
         request.put('donationId', opp.fr_Id__c);
         request.put('answer', updatedAnswer);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question-answer';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         Test.startTest();
-        
         frWSCustomQuestionAnswerController.syncEntity();
-        
         Test.stopTest();
         frTestUtil.assertNoErrors();
+        
         Answer__c answer = [SELECT Id, fr_ID__c, Answer__c, Question__c, Transaction__c
                             FROM Answer__c WHERE fr_ID__c = :funraiseId];
         
@@ -229,18 +201,10 @@ public class frAnswerTest {
         request.put('donationId', opp.fr_Id__c);
 		request.put('deleted', true);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question-answer';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         Test.startTest();
-        
         frWSCustomQuestionAnswerController.syncEntity();
-        
         Test.stopTest();
         frTestUtil.assertNoErrors();
         
@@ -256,20 +220,13 @@ public class frAnswerTest {
         request.put('id', funraiseId);
         request.put('questionId', 'nonexistent');
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question-answer';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         frTestUtil.assertNoErrors();
         Test.startTest();
-        
         frWSCustomQuestionAnswerController.syncEntity();
-        
         Test.stopTest();
+        
         System.assertEquals(0, [SELECT COUNT() FROM Answer__c], 'Since the question relationship was missing, the answer should not have been created');
         System.assertEquals(1, [SELECT COUNT() FROM Sync_Attempt__c], 'A sync attempt should have been generated because of the missing question');   
     }
@@ -289,19 +246,11 @@ public class frAnswerTest {
         request.put('pageGoalId', badIdValue);
         request.put('registrationId', badIdValue);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question-answer';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         frTestUtil.assertNoErrors();
+        
         Test.startTest();
-        
         frWSCustomQuestionAnswerController.syncEntity();
-        
         Test.stopTest();
         System.assertEquals(1, [SELECT COUNT() FROM Answer__c], 'The required values were provided so the answer should exist');
     }

--- a/src/classes/frCampaign.cls
+++ b/src/classes/frCampaign.cls
@@ -38,23 +38,33 @@
 * AUTHOR: Jordan Speer
 */
 
-public class frCampaign {
-    
-    public frCampaign(Map<String, Object> request) {
-        if (Boolean.valueOf(request.get('deleted'))) {
-            deleteCampaign(request);
-        } else {
-            create(request);
-        }
+public class frCampaign extends frModel implements frSyncable {
+    public frCampaign(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
     
-    public void deleteCampaign(Map<String, Object> request) {
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+        if (Boolean.valueOf(request.get('deleted'))) {
+            result = deleteCampaign(request);
+        } else {
+            result = create(request);
+        }
+        return result;
+    }
+    
+    private Boolean deleteCampaign(Map<String, Object> request) {
+        Boolean result = false;
         String goalId = String.valueOf(request.get('goalId'));
         try {
             List<Campaign> campaigns = [SELECT Id, fr_ID__c, ParentId, 
                                  (SELECT Id, fr_ID__c, ParentId from ChildCampaigns)
                                  from Campaign where fr_ID__c = :goalId];
-            if(campaigns.size() == 0) {return;}
+            if(campaigns.size() == 0) {
+                return true;
+            }
             Campaign campaignToDelete = campaigns.get(0);
             if (campaignToDelete.ChildCampaigns.size() > 0) {
                 if(String.isNotBlank(campaignToDelete.ParentId)) {
@@ -67,13 +77,15 @@ public class frCampaign {
                 }
             }
             delete campaignToDelete;
-            return;
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.CAMPAIGN, goalId, e);
+            if(createLogRecord) frUtil.logException(frUtil.Entity.CAMPAIGN, goalId, e);
         }
+        return result;
     }
     
-    public void create(Map<String, Object> request) {
+    private Boolean create(Map<String, Object> request) {
+        Boolean result = false;
         String goalId = String.valueOf(request.get('goalId'));
         
         Campaign newCampaign = new Campaign();
@@ -89,15 +101,16 @@ public class frCampaign {
             if(parentCampaigns.size() > 0) {
                 newCampaign.ParentId = parentCampaigns.get(0).Id;                
             } else {
-                frUtil.logRelationshipError(frUtil.Entity.CAMPAIGN, goalId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.CAMPAIGN, goalId, 
                                             frUtil.Entity.CAMPAIGN, parentId);
             }
         }
         try {
             Database.upsert(newCampaign, Campaign.Field.fr_ID__c, true);
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.CAMPAIGN, goalId, e);
-			return;
+            if(createLogRecord) frUtil.logException(frUtil.Entity.CAMPAIGN, goalId, e);
+			return result;
         }
         
         String supporterFunraiseId = String.valueOf(request.get('supporterId'));        
@@ -113,15 +126,17 @@ public class frCampaign {
                     );
                     try {
                         insert fundraiserMember;
+                        result = true;
                     } catch (DMLException ex) {
-                        frUtil.logException(frUtil.Entity.CAMPAIGN, goalId, ex);
-                        return;
+                        if(createLogRecord) frUtil.logException(frUtil.Entity.CAMPAIGN, goalId, ex);
+                        result = false;
                     }
                 }
             } else {
-                frUtil.logRelationshipError(frUtil.Entity.CAMPAIGN, goalId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.CAMPAIGN, goalId, 
                                             frUtil.Entity.SUPPORTER, supporterFunraiseId);
             }
         }
+        return result;
     }
 }

--- a/src/classes/frCampaignTest.cls
+++ b/src/classes/frCampaignTest.cls
@@ -48,17 +48,19 @@ public class frCampaignTest {
     static testMethod void createTopLevelCampaign_test() {	
         String goalId = '10';
         String campaignName = 'New Campaign';
-        Map<String, Object> request = new Map<String, Object>();
-        request.put('name', 'New Campaign');
-        request.put('reason', 'The campaign is new');
-        request.put('status', 'Published');
-        request.put('goalAmount', '238329.12');
-        request.put('parentGoalId', null);
+        Map<String, Object> request = getTestRequest();
         request.put('goalId', goalId);
-        request.put('deleted', false);
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
 
         Test.startTest();
-        new frCampaign(request);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
 
         Campaign newCampaign = [SELECT Id, fr_ID__c, Name FROM Campaign WHERE fr_ID__c = :goalId];
@@ -71,31 +73,31 @@ public class frCampaignTest {
         String childCampaignName = 'Child campaign';
         String childGoalId = '19';
         
-        Map<String, Object> parentRequest = new Map<String, Object>();
-        parentRequest.put('name', parentCampaignName);
-        parentRequest.put('reason', 'The campaign is new');
-        parentRequest.put('status', 'Published');
-        parentRequest.put('goalAmount', '238329.12');
-        parentRequest.put('parentGoalId', null);
-        parentRequest.put('goalId', parentGoalId);
-        parentRequest.put('deleted', false);
+        Campaign parentCampaign = getTestCampaign();
+        parentCampaign.fr_Id__c = parentGoalId;
+        update parentCampaign;
         
-        Map<String, Object> childRequest = new Map<String, Object>();
-        childRequest.put('name', childCampaignName);
-        childRequest.put('reason', 'The campaign is new');
-        childRequest.put('status', 'Published');
-        childRequest.put('goalAmount', '1200');
-        childRequest.put('parentGoalId', parentGoalId);
-        childRequest.put('goalId', childGoalId);
-        childRequest.put('deleted', false);
-        
-        new frCampaign(parentRequest);
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('name', childCampaignName);
+        request.put('reason', 'The campaign is new');
+        request.put('status', 'Published');
+        request.put('goalAmount', '1200');
+        request.put('parentGoalId', parentGoalId);
+        request.put('goalId', childGoalId);
+        request.put('deleted', false);
+
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
 
         Test.startTest();
-        new frCampaign(childRequest);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
 
-        Campaign parentCampaign = [SELECT Id, fr_ID__c FROM Campaign WHERE fr_ID__c = :parentGoalId];
         Campaign childCampaign = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE fr_ID__c = :childGoalId];
         System.assertEquals(childCampaignName, childCampaign.Name, 'The campaign name was not correct');
         System.assertEquals(parentCampaign.Id, childCampaign.ParentId, 'The campaign parentId was not correct');
@@ -114,8 +116,16 @@ public class frCampaignTest {
         childRequest.put('goalId', childGoalId);
         childRequest.put('deleted', false);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(childRequest));
+        RestContext.request = req;
+        RestContext.response = res;
+
         Test.startTest();
-        new frCampaign(childRequest);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
 
         List<Campaign> childCampaigns = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE fr_ID__c = :childGoalId];
@@ -135,8 +145,16 @@ public class frCampaignTest {
         topLevelCampaign.put('goalId', topLevelGoalId);
         topLevelCampaign.put('deleted', true);
         
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(topLevelCampaign));
+        RestContext.request = req;
+        RestContext.response = res;
+
         Test.startTest();
-        new frCampaign(topLevelCampaign);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
         
         List<Campaign> campaigns = [SELECT Id, ParentId, Parent.fr_ID__c FROM Campaign];
@@ -156,8 +174,16 @@ public class frCampaignTest {
         topLevelCampaign.put('goalId', topLevelGoalId);
         topLevelCampaign.put('deleted', true);
         
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(topLevelCampaign));
+        RestContext.request = req;
+        RestContext.response = res;
+
         Test.startTest();
-        new frCampaign(topLevelCampaign);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
         
         List<Campaign> campaigns = [SELECT Id, ParentId, Parent.fr_ID__c FROM Campaign];
@@ -169,17 +195,25 @@ public class frCampaignTest {
     static testMethod void testDeleteParent() {
         createCampaigns();
                 
-        Map<String, Object> parentRequest = new Map<String, Object>();
-        parentRequest.put('name', 'Parent Campaign');
-        parentRequest.put('reason', 'The campaign is new');
-        parentRequest.put('status', 'Published');
-        parentRequest.put('goalAmount', '238329.12');
-        parentRequest.put('parentGoalId', topLevelGoalId);
-        parentRequest.put('goalId', parentGoalId);
-        parentRequest.put('deleted', true);
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('name', 'Parent Campaign');
+        request.put('reason', 'The campaign is new');
+        request.put('status', 'Published');
+        request.put('goalAmount', '238329.12');
+        request.put('parentGoalId', topLevelGoalId);
+        request.put('goalId', parentGoalId);
+        request.put('deleted', true);
         
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+
         Test.startTest();
-        new frCampaign(parentRequest);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
         
         Campaign topLevelCampaign = [SELECT Id, fr_ID__c FROM Campaign WHERE fr_ID__c = :topLevelGoalId];
@@ -205,8 +239,16 @@ public class frCampaignTest {
         List<Campaign> childCampaigns = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE parentId = :parentCampaign.Id];
         System.assertEquals(childCampaigns.size(), 2, 'Number of children is incorrect');
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(grandchildCampaign2));
+        RestContext.request = req;
+        RestContext.response = res;
+
         Test.startTest();
-        new frCampaign(grandchildCampaign2);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
 
         childCampaigns = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE parentId = :parentCampaign.Id];
@@ -229,8 +271,16 @@ public class frCampaignTest {
         grandchildCampaign2.put('goalId', grandchildGoalId2);
         grandchildCampaign2.put('deleted', false);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(grandchildCampaign2));
+        RestContext.request = req;
+        RestContext.response = res;
+
         Test.startTest();
-        new frCampaign(grandchildCampaign2);
+        frWSCampaignController.syncEntity();
         Test.stopTest();
 
         Campaign campaign = [SELECT Id, fr_ID__c, Name, Description, ExpectedRevenue FROM Campaign WHERE fr_ID__c = :grandchildGoalId2];
@@ -254,12 +304,20 @@ public class frCampaignTest {
         request.put('goalId', goalId);
         request.put('deleted', false);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+
         Test.startTest();
         Integer startingErrors = [SELECT COUNT() FROM Error__c];
-        new frCampaign(request);
+        frWSCampaignController.syncEntity();
         
         //the same request twice shouldn't duplicate campaign members
-        new frCampaign(request);
+        frWSCampaignController.syncEntity();
         Integer afterErrors = [SELECT COUNT() FROM Error__c];
         Test.stopTest();
 
@@ -274,46 +332,43 @@ public class frCampaignTest {
     }
     
     static void createCampaigns() {
-        Map<String, Object> topLevelCampaign = new Map<String, Object>();
-        topLevelCampaign.put('name', 'Top level Campaign');
-        topLevelCampaign.put('reason', 'The campaign is old');
-        topLevelCampaign.put('status', 'Published');
-        topLevelCampaign.put('goalAmount', '238329.12');
-        topLevelCampaign.put('parentGoalId', null);
-        topLevelCampaign.put('goalId', topLevelGoalId);
-        topLevelCampaign.put('deleted', false);
+		Campaign topLevelCampaign = new Campaign(
+        	Name = 'Top level Campaign',
+            Description = 'The campaign is old',
+            Status = 'Published',
+            ExpectedRevenue = 238329.12,
+            fr_Id__c = topLevelGoalId
+        );
+        insert topLevelCampaign;
+		
+        Campaign childCampaign = new Campaign(
+        	Name = 'Second Level Campaign',
+            Description = 'The campaign is new',
+            Status = 'Published',
+            ExpectedRevenue = 1200,
+            fr_Id__c = parentGoalId,
+            ParentId = topLevelCampaign.Id
+        );
+        insert childCampaign;
         
-        Map<String, Object> childCampaign = new Map<String, Object>();
-        childCampaign.put('name', 'Second Level Campaign');
-        childCampaign.put('reason', 'The campaign is new');
-        childCampaign.put('status', 'Published');
-        childCampaign.put('goalAmount', '1200');
-        childCampaign.put('parentGoalId', topLevelGoalId);
-        childCampaign.put('goalId', parentGoalId);
-        childCampaign.put('deleted', false);
-        
-        Map<String, Object> grandchildCampaign1 = new Map<String, Object>();
-        grandchildCampaign1.put('name', 'Child campaign 1');
-        grandchildCampaign1.put('reason', 'The campaign is newer');
-        grandchildCampaign1.put('status', 'Published');
-        grandchildCampaign1.put('goalAmount', '232');
-        grandchildCampaign1.put('parentGoalId', parentGoalId);
-        grandchildCampaign1.put('goalId', grandchildGoalId1);
-        grandchildCampaign1.put('deleted', false);
-        
-        Map<String, Object> grandchildCampaign2 = new Map<String, Object>();
-        grandchildCampaign2.put('name', 'Child campaign 1');
-        grandchildCampaign2.put('reason', 'The campaign is newest');
-        grandchildCampaign2.put('status', 'Published');
-        grandchildCampaign2.put('goalAmount', '452');
-        grandchildCampaign2.put('parentGoalId', parentGoalId);
-        grandchildCampaign2.put('goalId', grandchildGoalId2);
-        grandchildCampaign2.put('deleted', false);
-        
-        new frCampaign(topLevelCampaign);
-        new frCampaign(childCampaign);
-        new frCampaign(grandchildCampaign1);
-        new frCampaign(grandchildCampaign2);
+        Campaign grandchildCampaign1 = new Campaign(
+        	Name = 'Child campaign 1',
+            Description = 'The campaign is newer',
+            Status = 'Published',
+            ExpectedRevenue = 232,
+            fr_Id__c = grandchildGoalId1,
+            ParentId = childCampaign.Id
+        );
+                
+        Campaign grandchildCampaign2 = new Campaign(
+        	Name = 'Child campaign 2',
+            Description = 'The campaign is newest',
+            Status = 'Published',
+            ExpectedRevenue = 452,
+            fr_Id__c = grandchildGoalId2,
+            ParentId = childCampaign.Id
+        );
+        insert new List<Campaign>{grandchildCampaign1, grandchildCampaign2};
     }
     
     public static Campaign getTestCampaign() {
@@ -325,5 +380,16 @@ public class frCampaignTest {
         campaign.fr_ID__c = '19920602';
         insert campaign;
         return campaign;
+    }
+    
+    public static Map<String, Object> getTestRequest() {
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('name', 'New Campaign');
+        request.put('reason', 'The campaign is new');
+        request.put('status', 'Published');
+        request.put('goalAmount', '238329.12');
+        request.put('parentGoalId', null);
+        request.put('deleted', false);
+        return request;
     }
 }

--- a/src/classes/frCampaignTest.cls
+++ b/src/classes/frCampaignTest.cls
@@ -38,12 +38,11 @@
  * AUTHOR: Jordan Speer
  */
 @isTest
-public class frCampaignTest {
-    
-    static String topLevelGoalId = '13';
-    static String parentGoalId = '15';
-    static String grandchildGoalId1 = '25';
-    static String grandchildGoalId2 = '39';
+public class frCampaignTest {  
+    private static String topLevelGoalId = '13';
+    private static String parentGoalId = '15';
+    private static String grandchildGoalId1 = '25';
+    private static String grandchildGoalId2 = '39';
     
     static testMethod void createTopLevelCampaign_test() {	
         String goalId = '10';
@@ -51,18 +50,12 @@ public class frCampaignTest {
         Map<String, Object> request = getTestRequest();
         request.put('goalId', goalId);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
-
+        
         Campaign newCampaign = [SELECT Id, fr_ID__c, Name FROM Campaign WHERE fr_ID__c = :goalId];
         System.assertEquals(campaignName, newCampaign.Name, 'The campaign name was not correct');
     }
@@ -77,27 +70,17 @@ public class frCampaignTest {
         parentCampaign.fr_Id__c = parentGoalId;
         update parentCampaign;
         
-        Map<String, Object> request = new Map<String, Object>();
+        Map<String, Object> request = getTestRequest();
         request.put('name', childCampaignName);
-        request.put('reason', 'The campaign is new');
-        request.put('status', 'Published');
-        request.put('goalAmount', '1200');
         request.put('parentGoalId', parentGoalId);
         request.put('goalId', childGoalId);
-        request.put('deleted', false);
-
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
-
+        
         Campaign childCampaign = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE fr_ID__c = :childGoalId];
         System.assertEquals(childCampaignName, childCampaign.Name, 'The campaign name was not correct');
         System.assertEquals(parentCampaign.Id, childCampaign.ParentId, 'The campaign parentId was not correct');
@@ -107,27 +90,17 @@ public class frCampaignTest {
         String childCampaignName = 'Child campaign';
         String childGoalId = '19';
         
-        Map<String, Object> childRequest = new Map<String, Object>();
+        Map<String, Object> childRequest = getTestRequest();
         childRequest.put('name', childCampaignName);
-        childRequest.put('reason', 'The campaign is new');
-        childRequest.put('status', 'Published');
-        childRequest.put('goalAmount', '1200');
         childRequest.put('parentGoalId', parentGoalId);
         childRequest.put('goalId', childGoalId);
-        childRequest.put('deleted', false);
-
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(childRequest));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        
+        frTestUtil.createTestPost(childRequest);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
-
+        
         List<Campaign> childCampaigns = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE fr_ID__c = :childGoalId];
         System.assertEquals(1, childCampaigns.size(), 'The campaign should have been created even though its parent could not be found');
         Campaign childCampaign = childCampaigns.get(0);
@@ -136,52 +109,31 @@ public class frCampaignTest {
     }
     
     static testMethod void testDelete_missingRecord() {
-        Map<String, Object> topLevelCampaign = new Map<String, Object>();
-        topLevelCampaign.put('name', 'Top level Campaign');
-        topLevelCampaign.put('reason', 'The campaign is old');
-        topLevelCampaign.put('status', 'Published');
-        topLevelCampaign.put('goalAmount', '238329.12');
-        topLevelCampaign.put('parentGoalId', null);
-        topLevelCampaign.put('goalId', topLevelGoalId);
-        topLevelCampaign.put('deleted', true);
+        Map<String, Object> request = getTestRequest();
+        request.put('parentGoalId', null);
+        request.put('goalId', topLevelGoalId);
+        request.put('deleted', true);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(topLevelCampaign));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
         
         List<Campaign> campaigns = [SELECT Id, ParentId, Parent.fr_ID__c FROM Campaign];
         System.assertEquals(0, campaigns.size(), 'No exceptions should have been thrown and no data created for trying to delete a record that didnt exist');
-        
     }
     
     static testMethod void testDeleteTopLevel() {
         createCampaigns();
-                
-        Map<String, Object> topLevelCampaign = new Map<String, Object>();
-        topLevelCampaign.put('name', 'Top level Campaign');
-        topLevelCampaign.put('reason', 'The campaign is old');
-        topLevelCampaign.put('status', 'Published');
-        topLevelCampaign.put('goalAmount', '238329.12');
-        topLevelCampaign.put('parentGoalId', null);
-        topLevelCampaign.put('goalId', topLevelGoalId);
-        topLevelCampaign.put('deleted', true);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(topLevelCampaign));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        Map<String, Object> request = getTestRequest();
+        request.put('parentGoalId', null);
+        request.put('goalId', topLevelGoalId);
+        request.put('deleted', true);
+        
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
@@ -194,24 +146,14 @@ public class frCampaignTest {
     
     static testMethod void testDeleteParent() {
         createCampaigns();
-                
-        Map<String, Object> request = new Map<String, Object>();
-        request.put('name', 'Parent Campaign');
-        request.put('reason', 'The campaign is new');
-        request.put('status', 'Published');
-        request.put('goalAmount', '238329.12');
+        
+        Map<String, Object> request = getTestRequest();
         request.put('parentGoalId', topLevelGoalId);
         request.put('goalId', parentGoalId);
         request.put('deleted', true);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
@@ -225,32 +167,22 @@ public class frCampaignTest {
     
     static testMethod void testDeleteGrandChild() {
         createCampaigns();
-
-        Map<String, Object> grandchildCampaign2 = new Map<String, Object>();
-        grandchildCampaign2.put('name', 'Child campaign 1');
-        grandchildCampaign2.put('reason', 'The campaign is newest');
-        grandchildCampaign2.put('status', 'Published');
-        grandchildCampaign2.put('goalAmount', '452');
-        grandchildCampaign2.put('parentGoalId', parentGoalId);
-        grandchildCampaign2.put('goalId', grandchildGoalId2);
-        grandchildCampaign2.put('deleted', true);
+        
+        Map<String, Object> request = getTestRequest();
+        request.put('parentGoalId', parentGoalId);
+        request.put('goalId', grandchildGoalId2);
+        request.put('deleted', true);
         
         Campaign parentCampaign = [SELECT Id, fr_ID__c FROM Campaign WHERE fr_ID__c = :parentGoalId];
         List<Campaign> childCampaigns = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE parentId = :parentCampaign.Id];
         System.assertEquals(childCampaigns.size(), 2, 'Number of children is incorrect');
-
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(grandchildCampaign2));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
-
+        
         childCampaigns = [SELECT Id, fr_ID__c, Name, ParentId FROM Campaign WHERE parentId = :parentCampaign.Id];
         System.assertEquals(childCampaigns.size(), 1, 'Number of children is incorrect');
     }
@@ -261,28 +193,20 @@ public class frCampaignTest {
         String updatedName = 'Grandchild Campaign';
         String updatedReason = 'The campaign is bold';
         Decimal updatedGoal = 899;
-
-        Map<String, Object> grandchildCampaign2 = new Map<String, Object>();
-        grandchildCampaign2.put('name', updatedName);
-        grandchildCampaign2.put('reason', updatedReason);
-        grandchildCampaign2.put('status', 'Published');
-        grandchildCampaign2.put('goalAmount', updatedGoal);
-        grandchildCampaign2.put('parentGoalId', parentGoalId);
-        grandchildCampaign2.put('goalId', grandchildGoalId2);
-        grandchildCampaign2.put('deleted', false);
-
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(grandchildCampaign2));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        
+        Map<String, Object> request = getTestRequest();
+        request.put('name', updatedName);
+        request.put('reason', updatedReason);
+        request.put('goalAmount', updatedGoal);
+        request.put('parentGoalId', parentGoalId);
+        request.put('goalId', grandchildGoalId2);
+        
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         frWSCampaignController.syncEntity();
         Test.stopTest();
-
+        
         Campaign campaign = [SELECT Id, fr_ID__c, Name, Description, ExpectedRevenue FROM Campaign WHERE fr_ID__c = :grandchildGoalId2];
         System.assertEquals(campaign.Name, updatedName, 'Name was not updated');
         System.assertEquals(campaign.Description, updatedReason, 'Description was not updated');
@@ -292,26 +216,16 @@ public class frCampaignTest {
     static testMethod void testCampaignMember() {
         Contact fundraiser = frDonorTest.getTestContact();
         
-		String goalId = '10';
+        String goalId = '10';
         String campaignName = 'New Campaign';
-        Map<String, Object> request = new Map<String, Object>();
+        Map<String, Object> request = getTestRequest();
         request.put('name', campaignName);
-        request.put('reason', 'The campaign is new');
-        request.put('status', 'Published');
-        request.put('goalAmount', '238329.12');
         request.put('parentGoalId', null);
         request.put('supporterId', fundraiser.fr_Id__c);
         request.put('goalId', goalId);
-        request.put('deleted', false);
-
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/campaign';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-
+        
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
         Integer startingErrors = [SELECT COUNT() FROM Error__c];
         frWSCampaignController.syncEntity();
@@ -320,7 +234,7 @@ public class frCampaignTest {
         frWSCampaignController.syncEntity();
         Integer afterErrors = [SELECT COUNT() FROM Error__c];
         Test.stopTest();
-
+        
         Campaign newCampaign = [SELECT Id, fr_ID__c, Name FROM Campaign WHERE fr_ID__c = :goalId];
         System.assertEquals(campaignName, newCampaign.Name, 'The campaign name was not correct');
         
@@ -332,17 +246,17 @@ public class frCampaignTest {
     }
     
     static void createCampaigns() {
-		Campaign topLevelCampaign = new Campaign(
-        	Name = 'Top level Campaign',
+        Campaign topLevelCampaign = new Campaign(
+            Name = 'Top level Campaign',
             Description = 'The campaign is old',
             Status = 'Published',
             ExpectedRevenue = 238329.12,
             fr_Id__c = topLevelGoalId
         );
         insert topLevelCampaign;
-		
+        
         Campaign childCampaign = new Campaign(
-        	Name = 'Second Level Campaign',
+            Name = 'Second Level Campaign',
             Description = 'The campaign is new',
             Status = 'Published',
             ExpectedRevenue = 1200,
@@ -352,16 +266,16 @@ public class frCampaignTest {
         insert childCampaign;
         
         Campaign grandchildCampaign1 = new Campaign(
-        	Name = 'Child campaign 1',
+            Name = 'Child campaign 1',
             Description = 'The campaign is newer',
             Status = 'Published',
             ExpectedRevenue = 232,
             fr_Id__c = grandchildGoalId1,
             ParentId = childCampaign.Id
         );
-                
+        
         Campaign grandchildCampaign2 = new Campaign(
-        	Name = 'Child campaign 2',
+            Name = 'Child campaign 2',
             Description = 'The campaign is newest',
             Status = 'Published',
             ExpectedRevenue = 452,

--- a/src/classes/frDataMigration.cls
+++ b/src/classes/frDataMigration.cls
@@ -37,8 +37,8 @@
 * CREATED: 2020 Funraise Inc - https://funraise.io
 * AUTHOR: Alex Molina
 */
-public class frDataMigration implements InstallHandler {
-    public void onInstall(InstallContext context) {
+public class frDataMigration {
+    public static void runMigrations() {
         //no migrations currently
     }
 }

--- a/src/classes/frDataMigrationTest.cls
+++ b/src/classes/frDataMigrationTest.cls
@@ -41,7 +41,7 @@ public class frDataMigrationTest {
     @isTest
     static void test() {
         Test.startTest();
-        new frDataMigration().onInstall(null);
+        frDataMigration.runMigrations();
         Test.stopTest();        
     }
 }

--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -38,22 +38,7 @@
 * AUTHOR: Jason M. Swenski
 */
 
-public class frDonation extends frModel {
-    //Donation statuses
-    private static final String COMPLETE = 'Complete';
-    private static final String PENDING = 'Pending';
-    private static final String REFUNDED = 'Refunded';
-    private static final String FAILED = 'Failed';
-    
-    //Opportunity Contact Role types
-    @TestVisible private static final String OPP_ROLE_DONOR = 'Donor';
-    @TestVisible private static final String OPP_ROLE_FUNDRAISER = 'Fundraiser';
-    @TestVisible private static final String OPP_ROLE_TEAM_CAPTAIN = 'Team Captain';
-    @TestVisible private static final String OPP_ROLE_SOFT_CREDIT = 'Soft Credit';
-    
-    private static final String META_OPP_CONTACT_MAPPING_KEY = 'opportunityContactMappingDisabled';
-    private static final String META_CAMPAIGN_MAPPING_KEY = 'campaignMappingDisabled';
-    
+public class frDonation extends frModel implements frSyncable {
     public static List<frMapping__c> mappings {
         get {
             if(mappings == null) {
@@ -64,23 +49,22 @@ public class frDonation extends frModel {
         set;
     }
     
-    public override List<frMapping__c> getMappings() {
+    protected override List<frMapping__c> getMappings() {
         return mappings;
-    }
-    public static final String TYPE = 'Donation';
-    protected override SObject getObject() {
-        return o;
     }
     
     private Opportunity o;
     
-    public Opportunity getOpportunity() {
-        return o;
+    public frDonation(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
     
-    public frDonation(Map<String, Object> request) {
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
         o = new Opportunity();
-        super.populateFromRequest(request);
+        applyMappings(o, request);
         String funraiseId = String.valueOf(request.get('id'));
         
         String status = String.valueOf(request.get('status'));
@@ -106,7 +90,7 @@ public class frDonation extends frModel {
                     o.AccountId = supporterContact.AccountId;
                 }
             } else {
-                frUtil.logRelationshipError(frUtil.Entity.DONATION, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.DONATION, funraiseId, 
                                             frUtil.Entity.SUPPORTER, supporterFunraiseId);
             }
         }
@@ -136,7 +120,7 @@ public class frDonation extends frModel {
                                             frUtil.Entity.SUBSCRIPTION, subscriptionId);
             }
         }
-        Opportunity opp = getOpportunity();
+        Opportunity opp = this.o;
         
         
         Boolean isPledge = Boolean.valueOf(request.get('pledge'));
@@ -149,16 +133,23 @@ public class frDonation extends frModel {
         
         try {
             Database.upsert(opp, Opportunity.Fields.fr_Id__c, true);
+            result = true;
         } catch (Exception ex) {
             frUtil.logException(frUtil.Entity.DONATION, funraiseId, ex);
         }
         
-        if(isPledge) {
+        if(isPledge && opp.Id != null) {
             frPledge.create(opp);
         }
-    }
+        
+        if(opp.Id != null) {
+            createOpportunityMapping(request);
+        }
+        return result;
+    } 
+   
     
-    public void createOpportunityMapping(Map<String, Object> request) {
+    private void createOpportunityMapping(Map<String, Object> request) {
         Boolean mappingDisabled = request.containsKey(META_OPP_CONTACT_MAPPING_KEY) ?
             Boolean.valueOf(request.get(META_OPP_CONTACT_MAPPING_KEY)): true;
         if(mappingDisabled) {
@@ -255,11 +246,27 @@ public class frDonation extends frModel {
         return newRole;
     }
     
-    public Boolean hasDonor() {
-        return getOpportunity() != null && getOpportunity().fr_Donor__c != null;
+    public String getOpportunityId() {
+        return this.o != null ? this.o.Id : null;
     }
     
-    public String getOpportunityId() {
-        return getOpportunity() != null ? getOpportunity().Id : null;
-    }
+    
+    ///CONSTANTS///
+
+    public static final String TYPE = 'Donation';
+    
+    //Donation statuses
+    private static final String COMPLETE = 'Complete';
+    private static final String PENDING = 'Pending';
+    private static final String REFUNDED = 'Refunded';
+    private static final String FAILED = 'Failed';
+    
+    //Opportunity Contact Role types
+    @TestVisible private static final String OPP_ROLE_DONOR = 'Donor';
+    @TestVisible private static final String OPP_ROLE_FUNDRAISER = 'Fundraiser';
+    @TestVisible private static final String OPP_ROLE_TEAM_CAPTAIN = 'Team Captain';
+    @TestVisible private static final String OPP_ROLE_SOFT_CREDIT = 'Soft Credit';
+    
+    private static final String META_OPP_CONTACT_MAPPING_KEY = 'opportunityContactMappingDisabled';
+    private static final String META_CAMPAIGN_MAPPING_KEY = 'campaignMappingDisabled';
 }

--- a/src/classes/frDonationTest.cls
+++ b/src/classes/frDonationTest.cls
@@ -40,17 +40,6 @@
 @isTest
 public class frDonationTest {
     static testMethod void syncEntity_newDonor() {  
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
-        req.requestBody = Blob.valueOf(getTestPayload());
-        
-        RestContext.request = req;
-        RestContext.response = res;
-        
         createMapping('name', 'Name');
         createMapping('name', 'Description');
         createMapping('amount', 'amount');
@@ -59,6 +48,7 @@ public class frDonationTest {
         insert new frMapping__c(Name = 'Test Percent', Is_Constant__c = true, Constant_Value__c = '95', sf_Name__c = 'Probability', Type__c = frDonation.TYPE);
         insert new frMapping__c(Name = 'Test Double', Is_Constant__c = true, Constant_Value__c = '1.5', sf_Name__c = 'totalopportunityquantity', Type__c = frDonation.TYPE);
         
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
         
         frWSDonationController.syncEntity();
@@ -70,8 +60,7 @@ public class frDonationTest {
         System.assertEquals('Closed Won', newOpportunity.StageName, 'The constant mapping for StageName was not used');
         System.assertEquals(95, newOpportunity.Probability, 'The constant mapping for Probability was not used');
         System.assertEquals(1.5, newOpportunity.TotalOpportunityQuantity, 'The constant mapping for Total Opportunity Quantity was not used');
-        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(req.requestBody.toString());
-        String expectedNameAndDesc = (String)body.get('name');
+        String expectedNameAndDesc = String.valueOf(getTestRequest().get('name'));
         //assert that we can use the same funraise field to 2 different SF fields
         System.assertEquals(expectedNameAndDesc, newOpportunity.Name, 'The mapping for name should have been applied');
         System.assertEquals(expectedNameAndDesc, newOpportunity.Description, 'The mapping for desc should have been applied');
@@ -79,21 +68,13 @@ public class frDonationTest {
     
     static testMethod void syncEntity_existingDonor() { 
         Contact testContact = frDonorTest.getTestContact();
-        
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
+        
+        frTestUtil.createTestPost(getTestRequest());
+        
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -105,26 +86,21 @@ public class frDonationTest {
     
     
     static testMethod void syncEntity_CampaignDonation() { 
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
         Contact testContact = frDonorTest.getTestContact();
         
         Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
+
+        Map<String, Object> request = getTestRequest();
+        request.put('campaignGoalId', 10);
+        request.put('campaignMappingDisabled', false);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayloadCampaign());
-        RestContext.request = req;
-        RestContext.response = res;
-        createMapping('name', 'Name');
-        createMapping('donation_cretime', 'CloseDate');
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -143,22 +119,15 @@ public class frDonationTest {
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        Map<String, Object> request = getTestRequest();
-        request.put('status', 'Refunded');
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
+        
+        Map<String, Object> request = getTestRequest();
+        request.put('status', 'Refunded');       
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();        
@@ -168,6 +137,9 @@ public class frDonationTest {
     }
     
     static testMethod void syncEntity_newOpportunityRoleMappings() { 
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+        
         Contact donor = frDonorTest.getTestContact(false);
         donor.fr_Id__c = '1';
         donor.Email = 'donor@example.com';
@@ -179,25 +151,15 @@ public class frDonationTest {
         teamCaptain.Email = 'teamCaptain@example.com';
         insert new List<Contact>{donor, fundraiser, teamCaptain};
             
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
         Map<String, Object> request = getTestRequest();
         request.put('opportunityContactMappingDisabled', 'false');
         request.put('donorId', donor.fr_Id__c);
         request.put('fundraiserId', fundraiser.fr_ID__c);
         request.put('teamCaptainId', teamCaptain.fr_ID__c);
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-        createMapping('name', 'Name');
-        createMapping('donation_cretime', 'CloseDate');
+
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -220,6 +182,9 @@ public class frDonationTest {
     }
     
     static testMethod void syncEntity_newOpportunityRoleMappings_missingContacts() { 
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+        
         Contact donor = frDonorTest.getTestContact(false);
         donor.fr_Id__c = '1';
         donor.Email = 'donor@example.com';
@@ -231,25 +196,15 @@ public class frDonationTest {
         teamCaptain.Email = 'teamCaptain@example.com';
         insert new List<Contact>{donor, fundraiser, teamCaptain};
             
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
         Map<String, Object> request = getTestRequest();
         request.put('opportunityContactMappingDisabled', 'false');
         request.put('donorId', donor.fr_Id__c);
         request.put('fundraiserId', fundraiser.fr_ID__c+'1');
         request.put('teamCaptainId', teamCaptain.fr_ID__c+'1');
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-        createMapping('name', 'Name');
-        createMapping('donation_cretime', 'CloseDate');
+        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
                 
         String oppFrId = String.valueOf(getTestRequest().get('id'));
@@ -260,31 +215,20 @@ public class frDonationTest {
     }
     
     static testMethod void syncEntity_LinkToSubscription() {  
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+        
         Contact testSupporter = frDonorTest.getTestContact();
         
         Subscription__c subscription = new Subscription__c(Name = 'Test Sub', fr_ID__c = '1234', Supporter__c = testSupporter.Id);
         insert subscription;
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
         Map<String, Object> request = getTestRequest();
         request.put('subscriptionId', subscription.fr_ID__c);
-        req.requestBody = Blob.valueOf(Json.serialize(request));
         
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('name', 'Name');
-        createMapping('donation_cretime', 'CloseDate');
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -295,30 +239,17 @@ public class frDonationTest {
     }
     
     static testMethod void syncEntity_LinkToPledge() {  
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+        
         Contact testSupporter = frDonorTest.getTestContact();
         
         Pledge__c pledge = getTestPledge(testSupporter);
         insert pledge;
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
-        Map<String, Object> request = getTestRequest();
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('name', 'Name');
-        createMapping('donation_cretime', 'CloseDate');
-        
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -328,29 +259,18 @@ public class frDonationTest {
     }
     
     static testMethod void syncEntity_PledgeCreatesPledge() {  
-        Contact testSupporter = frDonorTest.getTestContact();
-        
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
-        Map<String, Object> request = getTestRequest();
-        request.put('pledge', true);
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        
-        RestContext.request = req;
-        RestContext.response = res;
-        
         createMapping('name', 'Name');
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
         
+        Contact testSupporter = frDonorTest.getTestContact();
+        
+        Map<String, Object> request = getTestRequest();
+        request.put('pledge', true);
+        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();        
@@ -366,6 +286,9 @@ public class frDonationTest {
     }
     
     static testMethod void syncEntity_PledgeUpdatesPledge() {  
+        createMapping('name', 'Name');
+        createMapping('amount', 'amount');
+        createMapping('donation_cretime', 'CloseDate');
         Contact testSupporter = frDonorTest.getTestContact();
         
         Opportunity existingOpp = getTestOpp();
@@ -384,27 +307,13 @@ public class frDonationTest {
         System.assertEquals(pledge.Pledge_Donation__c +'', pledge.Pledge_Donation_uq__c+'',
                             'The external id unique field should have been updated with the value from the lookup field');
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('pledge', true);
-        req.requestBody = Blob.valueOf(Json.serialize(request));
         
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('name', 'Name');
-        createMapping('amount', 'amount');
-        createMapping('donation_cretime', 'CloseDate');
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -426,6 +335,10 @@ public class frDonationTest {
 * be an active pledge
 */
     static testMethod void syncEntity_existing_alreadyLinkedToPledge() {  
+        createMapping('name', 'Name');
+        createMapping('amount', 'amount');
+        createMapping('donation_cretime', 'CloseDate');
+        
         Contact testSupporter = frDonorTest.getTestContact();
         Pledge__c pledge = getTestPledge(testSupporter);
         pledge.End_Date__c = Date.today().addDays(-1); //so it's no longer active
@@ -435,27 +348,12 @@ public class frDonationTest {
         existingOpp.Funraise_Pledge__c = pledge.Id;
         insert existingOpp;
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
         Map<String, Object> request = getTestRequest();
         request.put('id', existingOpp.fr_Id__c);
-        req.requestBody = Blob.valueOf(Json.serialize(request));
         
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('name', 'Name');
-        createMapping('amount', 'amount');
-        createMapping('donation_cretime', 'CloseDate');
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -471,6 +369,10 @@ public class frDonationTest {
 * then they should get matched together
 */
     static testMethod void syncEntity_oldDonation_matchesInactivePledge() {  
+        createMapping('name', 'Name');
+        createMapping('amount', 'amount');
+        createMapping('donation_cretime', 'CloseDate');
+        
         Contact testSupporter = frDonorTest.getTestContact();
         //get a pledge that is inactive according to dates
         //but is unfulfilled in amount
@@ -478,28 +380,13 @@ public class frDonationTest {
         pledge.Start_Date__c = Date.today().addDays(-5);
         pledge.End_Date__c = Date.today().addDays(-1); 
         insert pledge;
-        
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('donation_cretime', DateTime.now().addDays(-3).getTime());
-        req.requestBody = Blob.valueOf(Json.serialize(request));
         
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('name', 'Name');
-        createMapping('amount', 'amount');
-        createMapping('donation_cretime', 'CloseDate');
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -515,6 +402,10 @@ public class frDonationTest {
 * then it should not be connected to the pledge
 */
     static testMethod void syncEntity_oldDonation_doesNotMatchInactivePledge() {  
+        createMapping('name', 'Name');
+        createMapping('amount', 'amount');
+        createMapping('donation_cretime', 'CloseDate');
+        
         Contact testSupporter = frDonorTest.getTestContact();
         //get a pledge that is inactive according to dates
         //but is unfulfilled in amount
@@ -522,28 +413,13 @@ public class frDonationTest {
         pledge.Start_Date__c = Date.today().addDays(-5);
         pledge.End_Date__c = Date.today().addDays(-1); 
         insert pledge;
-        
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
+  
         Map<String, Object> request = getTestRequest();
         request.put('donation_cretime', DateTime.now().getTime());
-        req.requestBody = Blob.valueOf(Json.serialize(request));
         
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('name', 'Name');
-        createMapping('amount', 'amount');
-        createMapping('donation_cretime', 'CloseDate');
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -558,14 +434,11 @@ public class frDonationTest {
 * only one role will be created, because multiple roles with the same contact can cause issues with reporting
 */
     static testMethod void syncEntity_oppContactRoles_sameSupporter() {  
+        createMapping('name', 'Name');
+        createMapping('amount', 'amount');
+        createMapping('donation_cretime', 'CloseDate');
         Contact testSupporter = frDonorTest.getTestContact();
-        
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donation';
-        req.httpMethod = 'POST';
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('opportunityContactMappingDisabled', false);
         request.put('donorId', testSupporter.fr_Id__c);
@@ -573,19 +446,9 @@ public class frDonationTest {
         request.put('teamCaptainId', testSupporter.fr_Id__c);
         request.put('softCreditSupporterId', testSupporter.fr_Id__c);
                 
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('name', 'Name');
-        createMapping('amount', 'amount');
-        createMapping('donation_cretime', 'CloseDate');
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonationController.syncEntity();
-        
         Test.stopTest();
         
         frTestUtil.assertNoErrors();
@@ -608,17 +471,6 @@ public class frDonationTest {
     
     private static void createMapping(String frField, String sfField) {
         insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonation.TYPE);
-    }
-    
-    private static String getTestPayload() {
-        return Json.serialize(getTestRequest());
-    }
-    
-    private static String getTestPayloadCampaign() {
-        Map<String, Object> testRequest = getTestRequest();
-        testRequest.put('campaignGoalId', 10);
-        testRequest.put('campaignMappingDisabled', false);
-        return Json.serialize(testRequest);
     }
     
     public static Map<String, Object> getTestRequest() {

--- a/src/classes/frDonationTest.cls
+++ b/src/classes/frDonationTest.cls
@@ -64,19 +64,9 @@ public class frDonationTest {
         frWSDonationController.syncEntity();
         
         Test.stopTest();
-        
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        List<Error__c> errors = [SELECT Id, Name, Error__c from Error__c];
-        System.assertEquals(1, errors.size(), 
-                            'They were unexpected errors. Errors: '+errors);
-        System.assert(errors.get(0).Error__c.contains('Failed to find related record'), 
-                      'The error message was not the expected one');
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, fr_ID__c, StageName, Name, Description, Probability, TotalOpportunityQuantity FROM Opportunity WHERE Id = :oppId];
+                
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, StageName, Name, Description, Probability, TotalOpportunityQuantity FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals('Closed Won', newOpportunity.StageName, 'The constant mapping for StageName was not used');
         System.assertEquals(95, newOpportunity.Probability, 'The constant mapping for Probability was not used');
         System.assertEquals(1.5, newOpportunity.TotalOpportunityQuantity, 'The constant mapping for Total Opportunity Quantity was not used');
@@ -106,13 +96,9 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT fr_Donor__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(testContact.Id, newOpportunity.fr_Donor__c, 
                             'The funraise sf donor id was not populated to the opportunity\'s contact lookup field');
     }
@@ -141,13 +127,9 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, CampaignId FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, CampaignId FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(testContact.Id, newOpportunity.fr_Donor__c, 
                             'The funraise sf donor id was not populated to the opportunity\'s contact lookup field');
         System.assertEquals(testCampaign.Id, newOpportunity.CampaignId, 
@@ -179,13 +161,9 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        frTestUtil.assertNoErrors();
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, StageName, fr_ID__c, fr_Donor__c FROM Opportunity WHERE Id = :oppId];
+        frTestUtil.assertNoErrors();        
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT Id, StageName, fr_ID__c, fr_Donor__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals('Closed Lost', newOpportunity.StageName, 'A status of refunded should have resulted in a Closed Lost stage');
     }
     
@@ -222,13 +200,10 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE fr_Id__c = :oppFrId];
         List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
         System.assertEquals(3, roles.size(), 'Expected to be a role for donor, fundraiser, and team captain');
         for(OpportunityContactRole role : roles) {
@@ -276,13 +251,9 @@ public class frDonationTest {
         frWSDonationController.syncEntity();
         
         Test.stopTest();
-        
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE Id = :oppId];
+                
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE fr_Id__c = :oppFrId];
         List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
         System.assertEquals(1, roles.size(), 'Since the request had ids that did not exist in SF, no roles should have been created except for the donor');
         System.assertEquals(2, [SELECT COUNT() FROM Error__c], 'There should be 3 error logs for missing supporters that prevented opp roles from being created');
@@ -316,13 +287,10 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, fr_ID__c, Subscription__c FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, Subscription__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(subscription.Id, newOpportunity.Subscription__c, 'The new donation should be pointing at the subscription corresponding to the id provided in the request');
     }
     
@@ -353,13 +321,9 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity newOpportunity = [SELECT Id, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity newOpportunity = [SELECT Id, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(pledge.Id, newOpportunity.Funraise_Pledge__c, 'The new donation should be pointing at the pledge that the supporter had active');
     }
     
@@ -389,13 +353,9 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        frTestUtil.assertNoErrors();
-        
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        frTestUtil.assertNoErrors();        
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertNotEquals(null, opp.Funraise_Pledge__c, 'The new donation should have created a new pledge');
         Pledge__c pledge = [SELECT Pledge_Donation_uq__c , Pledge_Donation__c, Pledge_Amount__c, Received_Amount__c from Pledge__c
                             WHERE Id = :opp.Funraise_Pledge__c];
@@ -447,13 +407,10 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertNotEquals(null, opp.Funraise_Pledge__c, 'The new donation should have created a new pledge');
         pledge = [SELECT Pledge_Donation_uq__c , Pledge_Donation__c, Pledge_Amount__c, Received_Amount__c from Pledge__c
                   WHERE Id = :opp.Funraise_Pledge__c];
@@ -501,13 +458,10 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(pledge.Id, opp.Funraise_Pledge__c, 'The pledge value should remain unchanged');
     }
     
@@ -548,13 +502,10 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(pledge.Id, opp.Funraise_Pledge__c, 'The donation should have matched to a previously active unfulfilled pledge');
     }
     
@@ -595,13 +546,10 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE Id = :oppId];
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(null, opp.Funraise_Pledge__c, 'The donation should not have matched to a previously active unfulfilled pledge');
     }
     
@@ -640,13 +588,9 @@ public class frDonationTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         frTestUtil.assertNoErrors();
         
-        Id oppId = response.id;
-        System.assert(String.isNotBlank(oppId), 
-                      'There was not an opportunity Id in the response as expected');
-        
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
         Set<String> funraiseRoles = new Set<String>{
             frDonation.OPP_ROLE_DONOR, 
             frDonation.OPP_ROLE_FUNDRAISER, 
@@ -655,7 +599,7 @@ public class frDonationTest {
         };
         Opportunity opp = [SELECT Id, Funraise_Pledge__c, 
                            (SELECT Id, Role FROM OpportunityContactRoles WHERE ContactId = :testSupporter.Id AND role IN :funraiseRoles) 
-                           FROM Opportunity WHERE Id = :oppId];
+                           FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(1, opp.OpportunityContactRoles.size(), 
                             'There should be a single opp contact role for the supporter');
         System.assertEquals(frDonation.OPP_ROLE_DONOR, opp.OpportunityContactRoles.get(0).role,
@@ -664,10 +608,6 @@ public class frDonationTest {
     
     private static void createMapping(String frField, String sfField) {
         insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonation.TYPE);
-    }
-    
-    public class MockResponse {
-        String id;
     }
     
     private static String getTestPayload() {
@@ -681,7 +621,7 @@ public class frDonationTest {
         return Json.serialize(testRequest);
     }
     
-    private static Map<String, Object> getTestRequest() {
+    public static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', 2048);
         request.put('organizationId', 'ae8d412b-db97-49dc-8c8c-5bfe0f41fc6d');

--- a/src/classes/frDonor.cls
+++ b/src/classes/frDonor.cls
@@ -38,7 +38,7 @@
 * AUTHOR: Jason M. Swenski
 */
 
-public class frDonor extends frModel {
+public class frDonor extends frModel implements frSyncable{
     public static final String TYPE = 'Donor';
     
     public static List<frMapping__c> mappings {
@@ -54,15 +54,17 @@ public class frDonor extends frModel {
     public override List<frMapping__c> getMappings() {
         return mappings;
     }
-    protected override SObject getObject() {
-        return getContact();
-    }
     
-    private String contactId;
-    private String id;
     private Contact c;
     
-    public frDonor(Map<String, Object> request) {
+    public frDonor(Sync_Attempt__c syncRecord){
+        super(syncRecord);
+    }
+    
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
         Contact supporterContact = null;
         String frId = String.valueOf(request.get('id'));
         //try to find a donor that's already been integrated, use their funraise ID
@@ -127,8 +129,7 @@ public class frDonor extends frModel {
         if(supporterContact == null) {
             supporterContact = new Contact(fr_Id__c = frId);
         }
-        setContact(supporterContact);
-        populateFromRequest(request);
+        applyMappings(supporterContact, request);
         
         if(String.isBlank(supporterContact.LastName)) {
             //LastName is required.  If the mappings didn't populate it, try to populate with the institution name
@@ -143,9 +144,12 @@ public class frDonor extends frModel {
             } else { 
                 Database.upsert(supporterContact, Contact.Fields.fr_ID__c, true);
             }
+            result = true;
         } catch (Exception ex) {
-            frUtil.logException(frUtil.Entity.SUPPORTER, frId, ex);
+            if(createLogRecord) frUtil.logException(frUtil.Entity.SUPPORTER, frId, ex);
+
         }
+        return result;
     }
     
     private Contact applyMatch(List<Contact> matchResults, String frId) {
@@ -155,17 +159,5 @@ public class frDonor extends frModel {
             return donor;
         }
         return null;
-    }
-    
-    private void setContact(Contact contact) {
-        this.c = contact;
-    }
-    
-    public Contact getContact() {
-        return c;
-    }
-    
-    public String getContactId() {
-        return getContact() != null ? getContact().Id : null;
     }
 }

--- a/src/classes/frDonorEmails.cls
+++ b/src/classes/frDonorEmails.cls
@@ -1,41 +1,44 @@
-public class frDonorEmails {
-    
-    public static String parseEmails(Map<String, Object> request, String funraiseId, String contactId) {
-        try {
-            EmailMessage email = new EmailMessage();
-            email.Status = '3';
-            email.FromAddress = String.valueOf(request.get('fromAddress'));
-            email.FromName = String.valueOf(request.get('fromName'));
-            email.toIds = new String[]{contactId};
-            email.subject = 'Funraise Email - ' + String.valueOf(request.get('subject'));
-            email.MessageDate = DateTime.newInstance((Long)request.get('sentDate')).dateGMT();
-            email.fr_Email_ID__c = funraiseId;
-            Database.upsert(email, EmailMessage.Fields.fr_Email_ID__c, true);
-            
-            EmailMessageRelation emr = new EmailMessageRelation();
-            emr.EmailMessageId = email.Id;
-            emr.RelationId = contactId;
-            emr.RelationType = 'ToAddress';
-            insert emr;
-            return email.Id;
-        } catch (DMLException ex) {
-            frUtil.logException(frUtil.Entity.EMAIL, funraiseId, ex);
-        }
-        return null;
+public class frDonorEmails extends frModel implements frSyncable {
+    public frDonorEmails(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
-
-    public static String create(Map<String, Object> request) {
+    
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+        
         String funraiseId = String.valueOf(request.get('id'));
         String supporterFunraiseId = String.valueOf(request.get('donorId'));        
         if (String.isNotBlank(supporterFunraiseId)) {
             List<Contact> contacts = [SELECT Id FROM Contact WHERE fr_ID__c = :supporterFunraiseId];
             if (contacts.size() > 0) {
-                return frDonorEmails.parseEmails(request, funraiseId, contacts.get(0).Id);
+                try {
+                    EmailMessage email = new EmailMessage();
+                    email.Status = '3';
+                    email.FromAddress = String.valueOf(request.get('fromAddress'));
+                    email.FromName = String.valueOf(request.get('fromName'));
+                    email.toIds = new String[]{contacts.get(0).Id};
+                    email.subject = 'Funraise Email - ' + String.valueOf(request.get('subject'));
+                    email.MessageDate = DateTime.newInstance((Long)request.get('sentDate')).dateGMT();
+                    email.fr_Email_ID__c = funraiseId;
+                    Database.upsert(email, EmailMessage.Fields.fr_Email_ID__c, true);
+                    
+                    EmailMessageRelation emr = new EmailMessageRelation();
+                    emr.EmailMessageId = email.Id;
+                    emr.RelationId = contacts.get(0).Id;
+                    emr.RelationType = 'ToAddress';
+                    insert emr;
+					result = true;
+                } catch (DMLException ex) {
+                    if(createLogRecord) frUtil.logException(frUtil.Entity.EMAIL, funraiseId, ex);
+                }
             } else {
-                frUtil.logRelationshipError(frUtil.Entity.EMAIL, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.EMAIL, funraiseId, 
                                             frUtil.Entity.SUPPORTER, supporterFunraiseId);
             }
         }
-        return null;
-    } 
+        
+        return result;
+    }
 }

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -40,11 +40,12 @@
 @isTest
 public class frDonorEmailsTest {
     static testMethod void create_ExistingContact_test() {
+        String emailId = '1234';
         Contact testContact = frDonorTest.getTestContact();
 
         Map<String, Object> request = new Map<String, Object>();
         request.put('donorId', testContact.fr_Id__c);
-        request.put('id', 4);
+        request.put('id', emailId);
         request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
         request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
         request.put('fromAddress', 'test@funraise.io');
@@ -54,12 +55,20 @@ public class frDonorEmailsTest {
         request.put('sentDate', 1536184380L);
         request.put('subject', 'Hello there!');
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/email';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        String responseEmailId = frDonorEmails.create(request);
+        frWSDonorEmailController.syncEntity();
         Test.stopTest();
 
         frTestUtil.assertNoErrors();
-        EmailMessage newEmail = [SELECT Id, fromAddress FROM EmailMessage WHERE Id = :responseEmailId];
+        EmailMessage newEmail = [SELECT Id, fromAddress FROM EmailMessage WHERE fr_Email_ID__c = :emailId];
         System.assertEquals('test@funraise.io', newEmail.fromAddress, 'The fromAddress was not correct');
     }
 
@@ -76,12 +85,20 @@ public class frDonorEmailsTest {
         request.put('sentDate', 1536184380L);
         request.put('subject', 'Hello there!');
         
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/email';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        String responseEmailId = frDonorEmails.create(request);
+        frWSDonorEmailController.syncEntity();
         Test.stopTest();
         
-        System.assertEquals(null, responseEmailId, 'We did not expect the email to be created created when the supporter could not be found');
-        System.assertEquals(1, [SELECT COUNT() FROM Error__c], 'There should be an error for not being able to find the related supporter');
+        System.assertEquals(0, [SELECT COUNT() FROM EmailMessage], 'We did not expect the email to be created created when the supporter could not be found');
+        System.assertEquals(1, [SELECT COUNT() FROM Sync_Attempt__c], 'There should be sync attempt generated to retry later');
     }
     
     static testMethod void syncEntity_test() {
@@ -92,7 +109,7 @@ public class frDonorEmailsTest {
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
 
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donoremail';
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/email';
         req.httpMethod = 'POST';
         req.requestBody = Blob.valueOf(getTestPayload());
         RestContext.request = req;
@@ -103,36 +120,32 @@ public class frDonorEmailsTest {
         frWSDonorEmailController.syncEntity();
 
         Test.stopTest();
-        
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
 
-		frTestUtil.assertNoErrors();        
-        Id emailId = response.id;
-        System.assert(String.isNotBlank(emailId), 'There was not an email Id in the response as expected');
-        EmailMessage newEmail = [SELECT fromAddress, (SELECT Id, RelationId FROM EmailMessageRelations WHERE RelationType = 'ToAddress') FROM EmailMessage WHERE Id = :emailId];
+		frTestUtil.assertNoErrors();      
+        EmailMessage newEmail = [SELECT fromAddress, (SELECT Id, RelationId FROM EmailMessageRelations WHERE RelationType = 'ToAddress') FROM EmailMessage WHERE fr_Email_Id__c = '4'];
         System.assertEquals('email@funraise.io', newEmail.fromAddress, 'The funraise email address was not correct');
         System.assertEquals(1, newEmail.EmailMessageRelations.size(), 'There should be a single email relation on the message. '+newEmail.EmailMessageRelations);
         Contact supporter = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :newEmail.EmailMessageRelations.get(0).RelationId];
         System.assertEquals(testContact.Id, supporter.Id, 'The email should have been associated with the contact with the same fr_ID__c as the request had');
         System.assertEquals(testContact.fr_Id__c, supporter.fr_ID__c, 'The email should have been associated with the contact referenced in the request');
     }
-
-    public class MockResponse {
-        String id;
+    
+    public static Map<String, Object> getTestRequest() {
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('donorId',856);
+        request.put('id', 4);
+        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
+        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
+        request.put('fromAddress', 'email@funraise.io');
+        request.put('fromName', 'John Smith');
+        request.put('toAddress', 'testEmail@google.com');
+        request.put('statusCode', 202);
+        request.put('sentDate', 1536184380L);
+        request.put('subject', 'Hello there');
+        return request;
     }
 
     private static String getTestPayload() {
-        return '{'+
-            '"donorId":856,'+
-            '"id": 4,'+
-            '"messageId": "db92570b-766b-46b9-8b7a-a0c7efa92053",'+
-            '"correlationId": "4aeeCRcARIamde0uiZAr6Q",'+
-            '"fromAddress": "email@funraise.io",' +
-            '"fromName": "John Smith",' +
-            '"toAddress": "testEmail@google.com",' +
-            '"statusCode": 202,'+
-            '"sentDate": ' + 1536184380L + ','+
-            '"subject": "Hello there"'+
-            '}';
+        return Json.serialize(getTestRequest());
     }
 }

--- a/src/classes/frDonorEmailsTest.cls
+++ b/src/classes/frDonorEmailsTest.cls
@@ -42,57 +42,30 @@ public class frDonorEmailsTest {
     static testMethod void create_ExistingContact_test() {
         String emailId = '1234';
         Contact testContact = frDonorTest.getTestContact();
-
-        Map<String, Object> request = new Map<String, Object>();
+        
+        Map<String, Object> request = getTestRequest();
         request.put('donorId', testContact.fr_Id__c);
         request.put('id', emailId);
-        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        request.put('fromAddress', 'test@funraise.io');
-        request.put('fromName', 'Bob Hope');
-        request.put('toAddress', 'notfunraise@funraise.io');
-        request.put('statusCode', 202);
-        request.put('sentDate', 1536184380L);
-        request.put('subject', 'Hello there!');
-
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
         
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/email';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonorEmailController.syncEntity();
         Test.stopTest();
-
+        
         frTestUtil.assertNoErrors();
         EmailMessage newEmail = [SELECT Id, fromAddress FROM EmailMessage WHERE fr_Email_ID__c = :emailId];
         System.assertEquals('test@funraise.io', newEmail.fromAddress, 'The fromAddress was not correct');
     }
-
+    
     static testMethod void createNoExistingContact_test() {
         String funraiseId = '2314';
-
-        Map<String, Object> request = new Map<String, Object>();
+        
+        Map<String, Object> request = getTestRequest();
         request.put('donorId', funraiseId);
         request.put('id', 2314);
-        request.put('emailId', 4);
-        request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
-        request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        request.put('statusCode', 202);
-        request.put('sentDate', 1536184380L);
-        request.put('subject', 'Hello there!');
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
+        frTestUtil.createTestPost(request);
         
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/email';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
         Test.startTest();
         frWSDonorEmailController.syncEntity();
         Test.stopTest();
@@ -106,24 +79,14 @@ public class frDonorEmailsTest {
         testContact.fr_ID__c = '856';
         insert testContact;
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/email';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-
         frWSDonorEmailController.syncEntity();
-
         Test.stopTest();
-
-		frTestUtil.assertNoErrors();      
+        
+        frTestUtil.assertNoErrors();      
         EmailMessage newEmail = [SELECT fromAddress, (SELECT Id, RelationId FROM EmailMessageRelations WHERE RelationType = 'ToAddress') FROM EmailMessage WHERE fr_Email_Id__c = '4'];
-        System.assertEquals('email@funraise.io', newEmail.fromAddress, 'The funraise email address was not correct');
+        System.assertEquals('test@funraise.io', newEmail.fromAddress, 'The funraise email address was not correct');
         System.assertEquals(1, newEmail.EmailMessageRelations.size(), 'There should be a single email relation on the message. '+newEmail.EmailMessageRelations);
         Contact supporter = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :newEmail.EmailMessageRelations.get(0).RelationId];
         System.assertEquals(testContact.Id, supporter.Id, 'The email should have been associated with the contact with the same fr_ID__c as the request had');
@@ -136,16 +99,12 @@ public class frDonorEmailsTest {
         request.put('id', 4);
         request.put('messageId', 'db92570b-766b-46b9-8b7a-a0c7efa92053');
         request.put('correlationId', '4aeeCRcARIamde0uiZAr6Q');
-        request.put('fromAddress', 'email@funraise.io');
+        request.put('fromAddress', 'test@funraise.io');
         request.put('fromName', 'John Smith');
         request.put('toAddress', 'testEmail@google.com');
         request.put('statusCode', 202);
         request.put('sentDate', 1536184380L);
         request.put('subject', 'Hello there');
         return request;
-    }
-
-    private static String getTestPayload() {
-        return Json.serialize(getTestRequest());
     }
 }

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -64,13 +64,9 @@ public class frDonorTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
-                      'There was not an contact Id in the response as expected');
-        Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
-        System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
+        String frId = String.valueOf(getTestRequest().get('id'));
+        Integer newContact = [SELECT COUNT() FROM Contact WHERE fr_Id__c = :frId];
+        System.assertEquals(1, newContact, 'The funraise donor id was not populated to the contact field');
     }
     
     //If the contact's last name field is blank, we'll assume its because there's no last name in funraise
@@ -102,13 +98,8 @@ public class frDonorTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
-                      'There was not an contact Id in the response as expected');
-        Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE Id = :contactId];
-        System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
+        String frId = String.valueOf(getTestRequest().get('id'));
+        Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE fr_Id__c = :frId];
         System.assertEquals(String.valueOf(requestBody.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
     }
     
@@ -145,13 +136,8 @@ public class frDonorTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
-                      'There was not an contact Id in the response as expected');
-        Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE Id = :contactId];
-        System.assertEquals(existingSupporter.fr_Id__c, newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
+        String frId = existingSupporter.fr_Id__c;
+        Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE fr_Id__c = :frId];
         System.assertEquals(String.valueOf(requestBody.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
     }
     
@@ -160,7 +146,7 @@ public class frDonorTest {
         Contact noMatch = new Contact(LastName = 'nomatch', FirstName = 'nomatch', Email = 'nomatch@example.com', fr_ID__c = '111');
         insert new List<Contact>{existing, noMatch};
             
-            Integer countBeforeSync = [SELECT COUNT() FROM Contact];
+        Integer countBeforeSync = [SELECT COUNT() FROM Contact];
         
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
@@ -185,13 +171,9 @@ public class frDonorTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
-                      'There was not an contact Id in the response as expected');
-        System.assertEquals(existing.Id, contactId, 'The existing contact should have been used');
-        Contact newContact = [SELECT Id, fr_ID__c, Email FROM Contact WHERE Id = :contactId];
+        String frId = String.valueOf(getTestRequest().get('id'));
+		Contact syncedContact = [SELECT Id, fr_ID__c, Email FROM Contact WHERE fr_Id__c = :frId];
+        System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
         Integer countAfterSync = [SELECT COUNT() FROM Contact];
         System.assertEquals(countBeforeSync, countAfterSync, 'No additional contacts should have been created');
     }
@@ -226,16 +208,11 @@ public class frDonorTest {
         
         Test.stopTest();
         frTestUtil.assertNoErrors();
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
-        
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
-                      'There was not an contact Id in the response as expected');
-        System.assertEquals(existing.Id, contactId, 'The existing contact should have been used');
-        Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
+        String frId = String.valueOf(getTestRequest().get('id'));
+        Contact syncedContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_Id__c = :frId];
+        System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
         Integer countAfterSync = [SELECT COUNT() FROM Contact];
         System.assertEquals(countBeforeSync, countAfterSync, 'No additional contacts should have been created');
-        System.assertEquals('856', newContact.fr_ID__c, 'The funraise Id should be populated on the existing contact matched by email');
     }
     
     static testMethod void syncEntity_existing_match_address() {
@@ -275,16 +252,11 @@ public class frDonorTest {
         
         Test.stopTest();
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class); 
-        
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
-                      'There was not an contact Id in the response as expected');
-        System.assertEquals(existing.Id, contactId, 'The existing contact should have been used');
-        Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
+        String frId = String.valueOf(getTestRequest().get('id'));
+        Contact syncedContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_Id__c = :frId];
+        System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
         Integer countAfterSync = [SELECT COUNT() FROM Contact];
         System.assertEquals(countBeforeSync, countAfterSync, 'No additional contacts should have been created');
-        System.assertEquals('856', newContact.fr_ID__c, 'The funraise Id should be populated on the existing contact matched by address');
     }
     
     static testMethod void syncEntity_badMappings() {
@@ -323,23 +295,15 @@ public class frDonorTest {
         }
         System.assertEquals(2, errors.size(), 'Only 2 bad mapping errors were expected (Date and Datetime fields): Errors:' + errorsStr);
         
-        MockResponse response = (MockResponse) JSON.deserialize(res.responseBody.toString(), MockResponse.class);
         
         //but even with bad field mappings the record should still come over correctly
-        Id contactId = response.id;
-        System.assert(String.isNotBlank(contactId), 
-                      'There was not an contact Id in the response as expected');
-        Contact newContact = [SELECT Id, fr_ID__c FROM Contact WHERE Id = :contactId];
-        
-        System.assertEquals('856', newContact.fr_ID__c, 'The funraise donor id was not populated to the contact field');
+        String frId = String.valueOf(getTestRequest().get('id'));
+        Integer newContacts = [SELECT COUNT() FROM Contact WHERE fr_Id__c = :frId];
+        System.assertEquals(1, newContacts, 'The funraise donor id was not populated to the contact field');
     }
     
     private static void createMapping(String frField, String sfField) {
         insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonor.TYPE);
-    }
-    
-    public class MockResponse {
-        String id;
     }
 
     public static Contact getTestContact(Boolean save) {
@@ -362,7 +326,7 @@ public class frDonorTest {
         return Json.serialize(getTestRequest());
     }
     
-    private static Map<String, Object> getTestRequest() {
+    public static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', 856);
         request.put('organizationId', 'ae8d412b-db97-49dc-8c8c-5bfe0f41fc6d');

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -40,15 +40,6 @@
 @isTest
 public class frDonorTest {
     static testMethod void syncEntity_test() {
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-        
         createMapping('firstName', 'FirstName');
         createMapping('lastName', 'LastName');
         createMapping('email', 'email');
@@ -58,10 +49,10 @@ public class frDonorTest {
         createMapping('postalCode', 'MailingPostalCode');
         createMapping('country', 'MailingCountry');
         createMapping('donor_cretime', 'BirthDate');
+        
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
         frWSDonorController.syncEntity();
-        
         Test.stopTest();
         
         String frId = String.valueOf(getTestRequest().get('id'));
@@ -72,18 +63,6 @@ public class frDonorTest {
     //If the contact's last name field is blank, we'll assume its because there's no last name in funraise
     //likely meaning it's an institution contact, so we should put the institution name in the last name field
     static testMethod void syncEntity_contactLastNameFallback() {
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
-        req.httpMethod = 'POST';
-        Map<String, Object> requestBody = getTestRequest();
-        requestBody.put('lastName', null);
-        requestBody.put('institutionName', 'Test Inst Name');
-        req.requestBody = Blob.valueOf(Json.serialize(requestBody));
-        RestContext.request = req;
-        RestContext.response = res;
-        
         createMapping('firstName', 'FirstName');
         createMapping('email', 'email');
         createMapping('address1', 'MailingStreet');
@@ -92,35 +71,24 @@ public class frDonorTest {
         createMapping('postalCode', 'MailingPostalCode');
         createMapping('country', 'MailingCountry');
         createMapping('donor_cretime', 'BirthDate');
+        
+        Map<String, Object> request = getTestRequest();
+        request.put('lastName', null);
+        request.put('institutionName', 'Test Inst Name');
+        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonorController.syncEntity();
-        
         Test.stopTest();
         
         String frId = String.valueOf(getTestRequest().get('id'));
         Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE fr_Id__c = :frId];
-        System.assertEquals(String.valueOf(requestBody.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
+        System.assertEquals(String.valueOf(request.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
     }
     
     //Sync to an existing contact that once the mappings are applied, LastName is empty so Salesforce will throw an exception
     //confirm our fallback works as expected to prevent that exception
     static testMethod void syncEntity_contactLastNameFallback_existing() {
-        Contact existingSupporter = getTestContact();
-        
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
-        req.httpMethod = 'POST';
-        Map<String, Object> requestBody = getTestRequest();
-        requestBody.put('id', existingSupporter.fr_Id__c);
-        requestBody.put('lastName', null);
-        requestBody.put('institutionName', 'Test Inst Name');
-        req.requestBody = Blob.valueOf(Json.serialize(requestBody));
-        RestContext.request = req;
-        RestContext.response = res;
-        
         createMapping('firstName', 'FirstName');
         createMapping('lastName', 'LastName');
         createMapping('email', 'email');
@@ -130,45 +98,43 @@ public class frDonorTest {
         createMapping('postalCode', 'MailingPostalCode');
         createMapping('country', 'MailingCountry');
         createMapping('donor_cretime', 'BirthDate');
+        
+        Contact existingSupporter = getTestContact();
+        
+        Map<String, Object> request = getTestRequest();
+        request.put('id', existingSupporter.fr_Id__c);
+        request.put('lastName', null);
+        request.put('institutionName', 'Test Inst Name');
+
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSDonorController.syncEntity();
-        
         Test.stopTest();
         
         String frId = existingSupporter.fr_Id__c;
         Contact newContact = [SELECT Id, fr_ID__c, LastName FROM Contact WHERE fr_Id__c = :frId];
-        System.assertEquals(String.valueOf(requestBody.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
+        System.assertEquals(String.valueOf(request.get('institutionName')), newContact.LastName, 'We expected a fallback so that the contact would still get created');
     }
     
     static testMethod void syncEntity_existing_match_funraise_id() {
+        createMapping('firstName', 'FirstName');
+        createMapping('lastName', 'LastName');
+        createMapping('email', 'email');
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry');
+        
         Contact existing = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'testExisting@example.com', fr_ID__c = '856');
         Contact noMatch = new Contact(LastName = 'nomatch', FirstName = 'nomatch', Email = 'nomatch@example.com', fr_ID__c = '111');
         insert new List<Contact>{existing, noMatch};
             
         Integer countBeforeSync = [SELECT COUNT() FROM Contact];
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
-        createMapping('email', 'email');
-        createMapping('address1', 'MailingStreet');
-        createMapping('city', 'MailingCity');
-        createMapping('state', 'MailingState');
-        createMapping('postalCode', 'MailingPostalCode');
-        createMapping('country', 'MailingCountry');
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
         frWSDonorController.syncEntity();
-        
         Test.stopTest();
         
         String frId = String.valueOf(getTestRequest().get('id'));
@@ -179,21 +145,6 @@ public class frDonorTest {
     }
     
     static testMethod void syncEntity_existing_match_email() {
-        Contact existing = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'alextest02221503@example.com');
-        Contact noMatch = new Contact(LastName = 'nomatch', FirstName = 'nomatch', Email = 'nomatch@example.com', fr_ID__c = '111');
-        insert new List<Contact>{existing, noMatch};
-            
-        Integer countBeforeSync = [SELECT COUNT() FROM Contact];
-        
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-        
         createMapping('firstName', 'FirstName');
         createMapping('lastName', 'LastName');
         createMapping('email', 'email');
@@ -202,12 +153,19 @@ public class frDonorTest {
         createMapping('state', 'MailingState');
         createMapping('postalCode', 'MailingPostalCode');
         createMapping('country', 'MailingCountry');
+        
+        Contact existing = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'alextest02221503@example.com');
+        Contact noMatch = new Contact(LastName = 'nomatch', FirstName = 'nomatch', Email = 'nomatch@example.com', fr_ID__c = '111');
+        insert new List<Contact>{existing, noMatch};
+            
+        Integer countBeforeSync = [SELECT COUNT() FROM Contact];
+
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
-        frWSDonorController.syncEntity();
-        
+        frWSDonorController.syncEntity();        
         Test.stopTest();
         frTestUtil.assertNoErrors();
+        
         String frId = String.valueOf(getTestRequest().get('id'));
         Contact syncedContact = [SELECT Id, fr_ID__c FROM Contact WHERE fr_Id__c = :frId];
         System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
@@ -216,6 +174,14 @@ public class frDonorTest {
     }
     
     static testMethod void syncEntity_existing_match_address() {
+        createMapping('firstName', 'FirstName');
+        createMapping('lastName', 'LastName');
+        createMapping('email', 'email');
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry');
         Contact existing = new Contact(LastName = 'test02221503', FirstName = 'alex', Email = 'testExisting@example.com',
                                        MailingStreet = '1234 S Street st',
                                        MailingCity = 'Test City',
@@ -227,29 +193,11 @@ public class frDonorTest {
         Contact noMatch = new Contact(LastName = 'nomatch', FirstName = 'nomatch', Email = 'nomatch@example.com', fr_ID__c = '111');
         insert new List<Contact>{existing, noMatch};
             
-            Integer countBeforeSync = [SELECT COUNT() FROM Contact];
+        Integer countBeforeSync = [SELECT COUNT() FROM Contact];
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-        
-        createMapping('firstName', 'FirstName');
-        createMapping('lastName', 'LastName');
-        createMapping('email', 'email');
-        createMapping('address1', 'MailingStreet');
-        createMapping('city', 'MailingCity');
-        createMapping('state', 'MailingState');
-        createMapping('postalCode', 'MailingPostalCode');
-        createMapping('country', 'MailingCountry');
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
         frWSDonorController.syncEntity();
-        
         Test.stopTest();
         
         String frId = String.valueOf(getTestRequest().get('id'));
@@ -260,15 +208,6 @@ public class frDonorTest {
     }
     
     static testMethod void syncEntity_badMappings() {
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/donor';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-        
         createMapping('firstName', 'FirstName');
         createMapping('lastName', 'LastName');
         createMapping('email', 'email');
@@ -282,10 +221,10 @@ public class frDonorTest {
         createMapping('institutionCategory', 'BirthDate');
         //bad mapping for datetime
         createMapping('p2gScore', 'LastCURequestDate');
+        
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
         frWSDonorController.syncEntity();
-        
         Test.stopTest();
         
         List<Error__c> errors = [SELECT Error__c FROM Error__c];
@@ -320,10 +259,6 @@ public class frDonorTest {
     
     public static Contact getTestContact() {
         return getTestContact(true);
-    }
-    
-    private static String getTestPayload() {
-        return Json.serialize(getTestRequest());
     }
     
     public static Map<String, Object> getTestRequest() {

--- a/src/classes/frFundraisingEvent.cls
+++ b/src/classes/frFundraisingEvent.cls
@@ -38,24 +38,36 @@
 * AUTHOR: Alex Molina
 */
 
-public class frFundraisingEvent {    
-    public frFundraisingEvent(Map<String, Object> request) {
-        if (Boolean.valueOf(request.get('deleted'))) {
-            deleteEvent(String.valueOf(request.get('id')));
-        } else {
-            create(request);
-        }
+public class frFundraisingEvent extends frModel implements frSyncable {    
+    
+    public frFundraisingEvent(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
     
-    public void deleteEvent(String funraiseId) {
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+        if (Boolean.valueOf(request.get('deleted'))) {
+            result = deleteEvent(String.valueOf(request.get('id')));
+        } else {
+            result = create(request);
+        }
+        return result;
+    }
+    
+    private boolean deleteEvent(String funraiseId) {
+        Boolean result = false;
         try {
             delete [SELECT id FROM Fundraising_Event__c WHERE fr_ID__c = :funraiseId];
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.EVENT, funraiseId, e);
+            if (createLogRecord) frUtil.logException(frUtil.Entity.EVENT, funraiseId, e);
         }
+        return result;
     }
     
-    public void create(Map<String, Object> request) {
+    private boolean create(Map<String, Object> request) {
+        Boolean result = false;
         String funraiseId = String.valueOf(request.get('id'));
         Fundraising_Event__c event = new Fundraising_Event__c(
         	fr_ID__c = funraiseId,
@@ -67,15 +79,17 @@ public class frFundraisingEvent {
 
         try {
             Database.upsert(event, Fundraising_Event__c.Field.fr_ID__c, true);
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.EVENT, funraiseId, e);
+            if (createLogRecord) frUtil.logException(frUtil.Entity.EVENT, funraiseId, e);
         }
+        return result;
     }
     
     private static DateTime convertFromLocalDateTime(List<Object> localDate, String recordId) {
         if(localDate != null && localDate.size() == 5) {
             try {
-                return frUtil.convertFromLocalDateTime(localDate);
+                return frModel.convertFromLocalDateTime(localDate);
             } catch (Exception ex) {
                 frUtil.logError(frUtil.Entity.EVENT, recordId, 'Could not parse event date.  Event created without this data');
             }

--- a/src/classes/frFundraisingEventRegistration.cls
+++ b/src/classes/frFundraisingEventRegistration.cls
@@ -38,31 +38,43 @@
 * AUTHOR: Alex Molina
 */
 
-public class frFundraisingEventRegistration {    
-    public frFundraisingEventRegistration(Map<String, Object> request) {
-        if (Boolean.valueOf(request.get('deleted'))) {
-            deleteRegistration(String.valueOf(request.get('id')));
-        } else {
-            create(request);
-        }
+public class frFundraisingEventRegistration extends frModel implements frSyncable {    
+    
+    public frFundraisingEventRegistration(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
     
-    public void deleteRegistration(String funraiseId) {
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+        if (Boolean.valueOf(request.get('deleted'))) {
+            result = deleteRegistration(String.valueOf(request.get('id')));
+        } else {
+            result = create(request);
+        }
+        return result;
+    }
+    
+    private Boolean deleteRegistration(String funraiseId) {
+        Boolean result = false;
         try {
             delete [SELECT id FROM Fundraising_Event_Registration__c WHERE fr_ID__c = :funraiseId];
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.REGISTRATION, funraiseId, e);
+            if(createLogRecord) frUtil.logException(frUtil.Entity.REGISTRATION, funraiseId, e);
         }
+        return result;
     }
     
-    public void create(Map<String, Object> request) {
+    private Boolean create(Map<String, Object> request) {
+        Boolean result = false;
         String funraiseId = String.valueOf(request.get('id'));
         String funraiseEventId = String.valueOf(request.get('eventId'));
         List<Fundraising_Event__c> event = [SELECT Id from Fundraising_Event__c WHERE fr_Id__c = :funraiseEventId];
         if(event.isEmpty()) {
-            frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
+            if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
                                         frUtil.Entity.EVENT, funraiseEventId);
-            return;
+            return result;
         }
         
         String funraiseSupporterId = String.valueOf(request.get('supporterId'));
@@ -71,7 +83,7 @@ public class frFundraisingEventRegistration {
             supporter = [SELECT Id from Contact WHERE fr_Id__c = :funraiseSupporterId];
             if(supporter.isEmpty()) {
                 //if it wasn't found, log an error but continue
-                frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
                                             frUtil.Entity.SUPPORTER, funraiseSupporterId,
                                             'Registration registrant');
             }
@@ -83,7 +95,7 @@ public class frFundraisingEventRegistration {
             guestOf = [SELECT Id from Contact WHERE fr_Id__c = :funraiseGuestOfId];
             if(guestOf.isEmpty()) {
                 //if it wasn't found, log an error but continue
-                frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
                                             frUtil.Entity.SUPPORTER, funraiseSupporterId,
                                             'Registration guest of');
                 
@@ -96,7 +108,7 @@ public class frFundraisingEventRegistration {
             transactions = [SELECT Id FROM Opportunity WHERE fr_Id__c = :funraiseTransactionId];
             if(transactions.isEmpty()) {
                 //if it wasn't found, log an error but continue
-                frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.REGISTRATION, funraiseId, 
                                             frUtil.Entity.DONATION, funraiseTransactionId);                
             }
         }
@@ -134,14 +146,14 @@ public class frFundraisingEventRegistration {
                 String.valueOf(request.get('email'))
             )
         );
-        frUtil.write(
+        frModel.write(
             registration, 
             Fundraising_Event_Registration__c.Ticket_Amount__c, 
             'Ticket_Amount__c',
             request.get('ticketAmount'),
             funraiseId
         );
-        frUtil.write(
+        frModel.write(
             registration, 
             Fundraising_Event_Registration__c.Ticket_Tax_Deductible_Amount__c, 
             'Ticket_Tax_Deductible_Amount__c',
@@ -151,9 +163,10 @@ public class frFundraisingEventRegistration {
         
         try {
             Database.upsert(registration, Fundraising_Event_Registration__c.Field.fr_ID__c, true);
+            result = true;
         } catch (DMLException ex) {
-            frUtil.logException(frUtil.Entity.REGISTRATION, funraiseId, ex);
-            return;
+            if(createLogRecord) frUtil.logException(frUtil.Entity.REGISTRATION, funraiseId, ex);
         }
+        return result;
     }
 }

--- a/src/classes/frFundraisingEventRegistrationTest.cls
+++ b/src/classes/frFundraisingEventRegistrationTest.cls
@@ -57,18 +57,9 @@ public class frFundraisingEventRegistrationTest {
         request.put('transactionId', testTransaction.fr_ID__c);
         request.put('id', funraiseId);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-
         frWSFundraisingEventRegistrationCntrlr.syncEntity();
-
         Test.stopTest();
         
         Fundraising_Event_Registration__c registration = [SELECT Id, fr_ID__c, Name, Attended__c, Ticket_Name__c, Ticket_Amount__c,
@@ -101,14 +92,7 @@ public class frFundraisingEventRegistrationTest {
         request.put('guestOfId', testSupporter.fr_Id__c);
         request.put('id', funraiseId);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
         Integer syncAttemptsBefore = [SELECT COUNT() FROM Sync_Attempt__c];
         frWSFundraisingEventRegistrationCntrlr.syncEntity();
@@ -135,14 +119,7 @@ public class frFundraisingEventRegistrationTest {
         request.put('guestOfId', guestOf.fr_Id__c);
         request.put('id', funraiseId);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
         frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();
@@ -186,14 +163,7 @@ public class frFundraisingEventRegistrationTest {
         request.put('guestOfId', 'nonexistent'); //not matching on guestOf is ok, we will create anyway
         request.put('id', funraiseId);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
         frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();
@@ -224,14 +194,7 @@ public class frFundraisingEventRegistrationTest {
         request.put('transactionId', 'nonexistent');
         request.put('id', funraiseId);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
         frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();
@@ -251,14 +214,7 @@ public class frFundraisingEventRegistrationTest {
         request.put('id', existingRegistration.fr_Id__c);
         request.put('deleted', true);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
         frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();

--- a/src/classes/frFundraisingEventRegistrationTest.cls
+++ b/src/classes/frFundraisingEventRegistrationTest.cls
@@ -101,17 +101,25 @@ public class frFundraisingEventRegistrationTest {
         request.put('guestOfId', testSupporter.fr_Id__c);
         request.put('id', funraiseId);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        Integer errorsBefore = [SELECT COUNT() FROM Error__c];
-        new frFundraisingEventRegistration(request);
-        Integer errorsAfter = [SELECT COUNT() FROM Error__c];
+        Integer syncAttemptsBefore = [SELECT COUNT() FROM Sync_Attempt__c];
+        frWSFundraisingEventRegistrationCntrlr.syncEntity();
+        Integer syncAttemptsAfter = [SELECT COUNT() FROM Sync_Attempt__c];
         Test.stopTest();
 
         List<Fundraising_Event_Registration__c> registrations = [SELECT Id, fr_ID__c, Name, Attended__c, Ticket_Name__c, Fundraising_Event__c, Guest_Of__c 
                                                                  FROM Fundraising_Event_Registration__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(0, registrations.size(), 'No registrations should have been created if an event id could not be matched');
-        System.assertEquals(0, errorsBefore, 'Precondition');
-        System.assertEquals(1, errorsAfter, 'An error log should have been created to record that an event id could not be matched');
+        System.assertEquals(0, syncAttemptsBefore, 'Precondition');
+        System.assertEquals(1, syncAttemptsAfter, 'A sync attempt should have been created to retry the registration later');
     }
     
     static testMethod void createRegistration_supporterMissing() {	
@@ -127,18 +135,22 @@ public class frFundraisingEventRegistrationTest {
         request.put('guestOfId', guestOf.fr_Id__c);
         request.put('id', funraiseId);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        Integer errorsBefore = [SELECT COUNT() FROM Error__c];
-        new frFundraisingEventRegistration(request);
-        Integer errorsAfter = [SELECT COUNT() FROM Error__c];
+        frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();
 
         List<Fundraising_Event_Registration__c> registrations = [SELECT Id, fr_ID__c, Name, Attended__c, Ticket_Name__c, 
                                                                  Fundraising_Event__c, Guest_Of__c 
                                                                  FROM Fundraising_Event_Registration__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(1, registrations.size(), 'A registration should have been created even if a supporter id could not be matched'); 
-        System.assertEquals(0, errorsBefore, 'Precondition');
-        System.assertEquals(1, errorsAfter, 'An error log should have been created to record that a supporter id could not be matched');
     }
     
     static testMethod void createRegistration_guestOfMissing() {	
@@ -174,10 +186,16 @@ public class frFundraisingEventRegistrationTest {
         request.put('guestOfId', 'nonexistent'); //not matching on guestOf is ok, we will create anyway
         request.put('id', funraiseId);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        Integer errorsBefore = [SELECT COUNT() FROM Error__c];
-        new frFundraisingEventRegistration(request);
-        Integer errorsAfter = [SELECT COUNT() FROM Error__c];
+        frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();
 
         Fundraising_Event_Registration__c registration = [SELECT Id, fr_ID__c, Name, Attended__c, Ticket_Name__c, Registrant__c,
@@ -190,8 +208,6 @@ public class frFundraisingEventRegistrationTest {
         System.assertEquals(testSupporter.Id, registration.Registrant__c, 'The lookup for supporter should have been populated with the contact that has the funraise id referenced in the request');
         System.assertEquals(null, registration.Guest_Of__c, 'The lookup for guest of should not have been populated since the request did not specify a valid id');
         System.assertEquals(null, registration.Transaction__c, 'The lookup for transaction__c should not have been populated with an opportunity');
-        System.assertEquals(0, errorsBefore, 'Precondition');
-        System.assertEquals(1, errorsAfter, 'An error log should have been created to record that a guest of id could not be matched');   
     }
     
     static testMethod void createRegistration_transactionMissing() {	
@@ -208,17 +224,21 @@ public class frFundraisingEventRegistrationTest {
         request.put('transactionId', 'nonexistent');
         request.put('id', funraiseId);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        Integer errorsBefore = [SELECT COUNT() FROM Error__c];
-        new frFundraisingEventRegistration(request);
-        Integer errorsAfter = [SELECT COUNT() FROM Error__c];
+        frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();
 
         Fundraising_Event_Registration__c registration = [SELECT Id, fr_ID__c, Transaction__c
                                                           FROM Fundraising_Event_Registration__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(null, registration.Transaction__c, 'The lookup for transaction__c should not have been populated with an opportunity');
-        System.assertEquals(0, errorsBefore, 'Precondition');
-        System.assertEquals(1, errorsAfter, 'An error log should have been created to record that a transaction could not be matched');   
     }
     
     static testMethod void deleteRegistration() {	
@@ -231,15 +251,23 @@ public class frFundraisingEventRegistrationTest {
         request.put('id', existingRegistration.fr_Id__c);
         request.put('deleted', true);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frFundraisingEventRegistration(request);
+        frWSFundraisingEventRegistrationCntrlr.syncEntity();
         Test.stopTest();
 
         frTestUtil.assertNoErrors();
         System.assertEquals(0, [SELECT COUNT() FROM Fundraising_Event_Registration__c], 'Registration should have been deleted and therefore not returned');
     }
 
-    private static Map<String, Object> getTestRequest() {
+    public static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('name', '000001');
         request.put('attended', true);

--- a/src/classes/frFundraisingEventTest.cls
+++ b/src/classes/frFundraisingEventTest.cls
@@ -43,18 +43,9 @@ public class frFundraisingEventTest {
         Map<String, Object> request = getTestRequest();
         String funraiseId = String.valueOf(request.get('id'));
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-
         frWSFundraisingEventController.syncEntity();
-
         Test.stopTest();
         
         Fundraising_Event__c newEvent = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
@@ -73,18 +64,9 @@ public class frFundraisingEventTest {
         request.put('eventStartDate', null);
         request.put('eventEndDate', null);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-
         frWSFundraisingEventController.syncEntity();
-
         Test.stopTest();
 
         Fundraising_Event__c newEvent = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
@@ -104,18 +86,10 @@ public class frFundraisingEventTest {
         }
         request.put('name', name);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
+        frTestUtil.createTestPost(request);
 
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
         Test.startTest();
-
         frWSFundraisingEventController.syncEntity();
-
         Test.stopTest();
 
         Fundraising_Event__c newEvent = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
@@ -132,18 +106,9 @@ public class frFundraisingEventTest {
         Map<String, Object> request = getTestRequest();
         request.put('id', null);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-
         frWSFundraisingEventController.syncEntity();
-
         Test.stopTest();
 
         List<Fundraising_Event__c> events = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
@@ -160,18 +125,9 @@ public class frFundraisingEventTest {
         Map<String, Object> request = getTestRequest();
         request.put('id', existingEvent.fr_Id__c);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-
         frWSFundraisingEventController.syncEntity();
-
         Test.stopTest();
 
         Fundraising_Event__c newEvent = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
@@ -192,18 +148,9 @@ public class frFundraisingEventTest {
         Fundraising_Event__c existingEvent = new Fundraising_Event__c(Name = 'Test Event', fr_Id__c = funraiseId);
         insert existingEvent;
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-
         frWSFundraisingEventController.syncEntity();
-
         Test.stopTest();
 
         List<Fundraising_Event__c> events = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 

--- a/src/classes/frFundraisingEventTest.cls
+++ b/src/classes/frFundraisingEventTest.cls
@@ -39,17 +39,9 @@
  */
 @isTest
 public class frFundraisingEventTest {  
-    static testMethod void createEvent_throughWS() {
-        String funraiseId = '25';
-        Map<String, Object> request = new Map<String, Object>();
-        List<Object> startDate = new List<Object> {2019, 05, 11, 9, 0};
-        List<Object> endDate = new List<Object> {2019, 05, 11, 4, 30};
-        request.put('name', 'Test Event');
-        request.put('description', 'This will be a fun fundraising event');
-        request.put('eventStartDate', startDate);
-        request.put('eventEndDate', endDate);
-        request.put('id', funraiseId);
-        request.put('deleted', false);
+    static testMethod void createEvent() {
+        Map<String, Object> request = getTestRequest();
+        String funraiseId = String.valueOf(request.get('id'));
         
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
@@ -76,17 +68,23 @@ public class frFundraisingEventTest {
     }
     
     static testMethod void createEvent_missingDates() {	
-        String funraiseId = '25';
-        Map<String, Object> request = new Map<String, Object>();
-        request.put('name', 'Test Event');
-        request.put('description', 'This will be a fun fundraising event');
+        Map<String, Object> request = getTestRequest();
+        String funraiseId = String.valueOf(request.get('id'));
         request.put('eventStartDate', null);
         request.put('eventEndDate', null);
-        request.put('id', funraiseId);
-        request.put('deleted', false);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frFundraisingEvent(request);
+
+        frWSFundraisingEventController.syncEntity();
+
         Test.stopTest();
 
         Fundraising_Event__c newEvent = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
@@ -98,23 +96,26 @@ public class frFundraisingEventTest {
     }
     
     static testMethod void createEvent_valueTooLong() {	
-        String funraiseId = '25';
-        Map<String, Object> request = new Map<String, Object>();
-        List<Object> startDate = new List<Object> {2019, 05, 11, 9, 0};
-        List<Object> endDate = new List<Object> {2019, 05, 11, 4, 30};
+        Map<String, Object> request = getTestRequest();
+        String funraiseId = String.valueOf(request.get('id'));
         String name = 'a';
         for(Integer i = 0; i < Fundraising_Event__c.Name.getDescribe().getLength() + 5; i++) {
             name += 'a';
         }
         request.put('name', name);
-        request.put('description', 'This will be a fun fundraising event');
-        request.put('eventStartDate', startDate);
-        request.put('eventEndDate', endDate);
-        request.put('id', funraiseId);
-        request.put('deleted', false);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frFundraisingEvent(request);
+
+        frWSFundraisingEventController.syncEntity();
+
         Test.stopTest();
 
         Fundraising_Event__c newEvent = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
@@ -128,46 +129,53 @@ public class frFundraisingEventTest {
     }
     
     static testMethod void createEvent_exception_noFunraiseId() {	
-        Map<String, Object> request = new Map<String, Object>();
-        request.put('name', 'Test Event');
-        request.put('description', 'This will be a fun fundraising event');
-        request.put('eventStartDate', null);
-        request.put('eventEndDate', null);
+        Map<String, Object> request = getTestRequest();
         request.put('id', null);
-        request.put('deleted', false);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frFundraisingEvent(request);
+
+        frWSFundraisingEventController.syncEntity();
+
         Test.stopTest();
 
         List<Fundraising_Event__c> events = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
                                          FROM Fundraising_Event__c];
         System.assertEquals(0, events.size(), 'Should not have created an event with invalid data (no funraise id provided)');
-        Integer errors = [SELECT COUNT() FROM Error__c];
-        System.assertEquals(1, errors, 'We expect an error to be created tracking the failure of creating the event');
+        Integer syncs = [SELECT COUNT() FROM Sync_Attempt__c];
+        System.assertEquals(1, syncs, 'A sync attempt should have been recorded to retry in the case of an exception');
     }
     
     static testMethod void updateEvent_allFields() {	
-        String funraiseId = '25';
         Fundraising_Event__c existingEvent = getTestEvent();
         insert existingEvent;
         
-        Map<String, Object> request = new Map<String, Object>();
-        List<Object> startDate = new List<Object> {2019, 05, 11, 9, 0};
-        List<Object> endDate = new List<Object> {2019, 05, 11, 4, 30};
-        request.put('name', 'Test Event');
-        request.put('description', 'This will be a fun fundraising event');
-        request.put('eventStartDate', startDate);
-        request.put('eventEndDate', endDate);
-        request.put('id', funraiseId);
-        request.put('deleted', false);
+        Map<String, Object> request = getTestRequest();
+        request.put('id', existingEvent.fr_Id__c);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frFundraisingEvent(request);
+
+        frWSFundraisingEventController.syncEntity();
+
         Test.stopTest();
 
         Fundraising_Event__c newEvent = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
-                                         FROM Fundraising_Event__c WHERE fr_ID__c = :funraiseId];
+                                         FROM Fundraising_Event__c WHERE fr_ID__c = :existingEvent.fr_Id__c];
         System.assertEquals(String.valueOf(request.get('name')), newEvent.Name, 'The event name should be the property included in the request');
         System.assertEquals(String.valueOf(request.get('description')), newEvent.Description__c, 'The event description should be the property included in the request');
         DateTime expectedStartDate = DateTime.newInstance(2019, 05, 11, 9, 0, 0);
@@ -177,30 +185,41 @@ public class frFundraisingEventTest {
     }
     
     static testMethod void deleteEvent() {	
-        String funraiseId = '25';
+        Map<String, Object> request = getTestRequest();
+        request.put('deleted', true);
+        String funraiseId = String.valueOf(request.get('id'));
+        
         Fundraising_Event__c existingEvent = new Fundraising_Event__c(Name = 'Test Event', fr_Id__c = funraiseId);
         insert existingEvent;
         
-        Map<String, Object> request = new Map<String, Object>();
-        List<Object> startDate = new List<Object> {2019, 05, 11, 9, 0};
-        List<Object> endDate = new List<Object> {2019, 05, 11, 4, 30};
-        request.put('name', 'Test Event');
-        request.put('description', 'This will be a fun fundraising event');
-        request.put('eventStartDate', startDate);
-        request.put('eventEndDate', endDate);
-        request.put('id', funraiseId);
-        request.put('deleted', true);
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
 
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frFundraisingEvent(request);
-        
-        //confirm that trying to delete a record that doesn't exist in SF also won't throw exceptions
-        request.put('id', funraiseId+'52');
+
+        frWSFundraisingEventController.syncEntity();
+
         Test.stopTest();
 
         List<Fundraising_Event__c> events = [SELECT Id, fr_ID__c, Name, Description__c, Start_Date__c, End_Date__c 
                                          FROM Fundraising_Event__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(0, events.size(), 'There should be no events matching the funraise id since it was marked as deleted');
+    }
+    
+    public static Map<String, Object> getTestRequest() {
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('name', 'Test Event');
+        request.put('description', 'This will be a fun fundraising event');
+        request.put('eventStartDate', new List<Object> {2019, 05, 11, 9, 0});
+        request.put('eventEndDate', new List<Object> {2019, 05, 11, 4, 30});
+        request.put('id', '25');
+        request.put('deleted', false);
+        return request;
     }
     
     public static Fundraising_Event__c getTestEvent() {

--- a/src/classes/frModel.cls
+++ b/src/classes/frModel.cls
@@ -1,9 +1,18 @@
 public abstract class frModel {
-	protected abstract SObject getObject();
-    public abstract List<frMapping__c> getMappings();
+    protected Sync_Attempt__c syncRecord;
+    protected Boolean createLogRecord = false;
 
-    public virtual void populateFromRequest(Map<String, Object> request) {
-    	Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(getObject().getSObjectType().getDescribe().getName());
+    public frModel(Sync_Attempt__c attempt) {
+        this.syncRecord = attempt;
+        createLogRecord = attempt.Attempts__c >= frSyncRequestHandler.MAX_ATTEMPTS;
+    }
+    
+    protected virtual List<frMapping__c> getMappings() {
+        return new List<frMapping__c>();
+    }
+    
+    protected void applyMappings(SObject record, Map<String, Object> request) {
+    	Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(record.getSObjectType().getDescribe().getName());
         String funraiseId = String.valueOf(request.get('id'));
         
         //a single funraise field might flow into multiple salesforce fields
@@ -28,16 +37,86 @@ public abstract class frModel {
             if(request.containsKey(fieldName)) {
                 for(frMapping__c mapping : frNameToSfName.get(fieldName)) {
                     Schema.SObjectField field = fields.get(mapping.sf_Name__c);
-                    frUtil.write(getObject(), field, mapping.sf_Name__c, request.get(fieldName), funraiseId);                    
+                    write(record, field, mapping.sf_Name__c, request.get(fieldName), funraiseId);                    
                 }
             }
         }
         for(frMapping__c constantMapping : constantMappings) {
             Schema.SObjectField field = fields.get(constantMapping.sf_Name__c);
-            frUtil.write(getObject(), field, constantMapping.sf_Name__c, constantMapping.Constant_Value__c, funraiseId);
+            write(record, field, constantMapping.sf_Name__c, constantMapping.Constant_Value__c, funraiseId);
         }
 
-        getObject().put('fr_ID__c', funraiseId);
+        record.put('fr_ID__c', funraiseId);
+    }
+    
+    public static void write(SObject record, Schema.SObjectField field, String fieldName, Object value, String funraiseId) {
+        try {
+            if (fieldName.toLowerCase() == 'id') {
+                if (value != null && ((String)value) != '') {
+                    record.put(field, Id.valueOf((String)value));
+                }
+            } else if (field.getDescribe().getType() == Schema.DisplayType.DateTime) {
+                record.put(field, DateTime.newInstance((Long)value));
+            } else if (field.getDescribe().getType() == Schema.DisplayType.Date) {
+                if(value instanceof List<Object>) {
+                    List<Object> localDate = (List<Object>)value;
+                    if(localDate.size() > 3) {
+                        DateTime sfLocalDateTime = convertFromLocalDateTime(localDate);
+                        record.put(field, sfLocalDateTime);                        
+                    } else if (localDate.size() == 3) {
+                        Date sfLocalDate = convertFromLocalDate(localDate);
+                        record.put(field, sfLocalDate);                        
+                    }
+                    
+                } else {
+                    record.put(field, DateTime.newInstance((Long)value).date());
+                }
+            } else if(field.getDescribe().getType() == Schema.DisplayType.Double) {
+                record.put(field, Double.valueOf(value));
+            } else if(field.getDescribe().getType() == Schema.DisplayType.Integer) {
+                record.put(field, Integer.valueOf(value));
+            } else if(field.getDescribe().getType() == Schema.DisplayType.Percent) {
+                record.put(field, Decimal.valueOf(String.valueOf(value)));
+            } else {
+                write(record, field, value, funraiseId);
+            }
+        }
+        catch (Exception e) {
+            write(record, field, value, funraiseId);
+        }
+    }
+    
+    private static void write(SObject record, Schema.SObjectField field, Object value, String funraiseId) {
+        try {
+            if(value instanceof String) {
+                value = frUtil.truncateToFieldLength(field.getDescribe(), (String)value);
+            }
+            record.put(field, value);
+        } catch (Exception ex) {
+            insert new Error__c(Error__c = 'Field mapping exception. Object type: '+ record.getSObjectType().getDescribe().getName()
+                +' Record Id: '+record.Id+' - Funraise Id: '+ funraiseId + ' - Field: '+field.getDescribe().getName()+' - Value: '+value
+                +' Exception: '+ex
+            );
+        }
+    }
+    
+    public static DateTime convertFromLocalDateTime(List<Object> localDateTime) {
+        return DateTime.newInstance(
+            (Integer)localDateTime.get(0), //year
+            (Integer)localDateTime.get(1), //month
+            (Integer)localDateTime.get(2), //day
+            (Integer)localDateTime.get(3), //hour
+            (Integer)localDateTime.get(4), //minute
+            0 				  //second
+        );
+    }
+    
+    public static Date convertFromLocalDate(List<Object> localDate) {
+        return Date.newInstance(
+            (Integer)localDate.get(0), //year
+            (Integer)localDate.get(1), //month
+            (Integer)localDate.get(2)  //day
+        );
     }
     
     public static void flushLogs() {

--- a/src/classes/frPostInstall.cls
+++ b/src/classes/frPostInstall.cls
@@ -30,19 +30,16 @@
 *
 *
 *
-* PURPOSE:
+* PURPOSE: A class to migrate data between releases of the Salesforce managed package.  
+* 	primarily in cases where one field is being replaced by another and we need to copy data.
 *
 *
-*
-* CREATED: 9-18-2018 Funraise Inc - https://funraise.io
-* AUTHOR: Mark D. Dufresne
+* CREATED: 2021 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
 */
-
-@RestResource(urlMapping='/v1/task')
-global with sharing class frWSTaskController {
-    
-    @HttpPost
-    global static void syncEntity() {
-        frWSBaseController.syncEntity(frUtil.Entity.TASK);
+public class frPostInstall implements InstallHandler {
+    public void onInstall(InstallContext context) {
+        frDataMigration.runMigrations();
+        frSetupController.setupScheduledJobs();
     }
 }

--- a/src/classes/frPostInstall.cls-meta.xml
+++ b/src/classes/frPostInstall.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frPostInstallTest.cls
+++ b/src/classes/frPostInstallTest.cls
@@ -34,15 +34,24 @@
 *
 *
 *
-* CREATED: 9-18-2018 Funraise Inc - https://funraise.io
-* AUTHOR: Mark D. Dufresne
+* CREATED: 2021 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
 */
-
-@RestResource(urlMapping='/v1/task')
-global with sharing class frWSTaskController {
-    
-    @HttpPost
-    global static void syncEntity() {
-        frWSBaseController.syncEntity(frUtil.Entity.TASK);
+@isTest
+public class frPostInstallTest {
+    static testMethod void testJobsScheduled() {
+        //Apex test contexts still pick up regular (non-test) scheduled jobs, so unscheduled them in this test
+        //to confirm they get scheduled as expected from a clean slate
+        for (CronTrigger activeJob : [SELECT Id FROM CronTrigger 
+                                        WHERE State NOT IN ('ERROR', 'DELETED') AND
+                                      CronJobDetail.Name IN :frSyncRequestScheduler.ALL_JOBS]) {
+        	System.abortJob(activeJob.Id);                                  
+        }
+        
+        Test.startTest();
+        new frPostInstall().onInstall(null);
+        Test.stopTest();      
+        Integer actualJobsScheduled = [SELECT COUNT() FROM CronTrigger WHERE State NOT IN ('ERROR', 'DELETED') AND CronJobDetail.Name IN :frSyncRequestScheduler.ALL_JOBS];
+        System.assertEquals(4, actualJobsScheduled, 'There should have been 4 jobs scheduled after the post install method runs');
     }
 }

--- a/src/classes/frPostInstallTest.cls-meta.xml
+++ b/src/classes/frPostInstallTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frQuestion.cls
+++ b/src/classes/frQuestion.cls
@@ -38,27 +38,41 @@
 * AUTHOR: Alex Molina
 */
 
-public class frQuestion {
+public class frQuestion extends frModel implements frSyncable {
     public static final Map<String, Schema.SObjectField> fields = 
         frSchemaUtil.getFields(Question__c.getSObjectType().getDescribe().getName());
     
-    public frQuestion(Map<String, Object> request) {
-        if (Boolean.valueOf(request.get('deleted'))) {
-            deleteQuestion(String.valueOf(request.get('id')));
-        } else {
-            create(request);
-        }
+    public frQuestion(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
     
-    public void deleteQuestion(String funraiseId) {
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+        
+        if (Boolean.valueOf(request.get('deleted'))) {
+            result = deleteQuestion(String.valueOf(request.get('id')));
+        } else {
+            result = create(request);
+        }
+
+    	return result;
+    }
+    
+    private Boolean deleteQuestion(String funraiseId) {
+        Boolean result = false;
         try {
             delete [SELECT id FROM Question__c WHERE fr_ID__c = :funraiseId];
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.SUBSCRIPTION, funraiseId, e);
+            if(createLogRecord) frUtil.logException(frUtil.Entity.QUESTION, funraiseId, e);
         }
+        return result;
     }
     
-    public void create(Map<String, Object> request) {
+    public Boolean create(Map<String, Object> request) {
+        Boolean result = false;
         String funraiseId = String.valueOf(request.get('id'));
 		Question__c question = new Question__c(
 			fr_Id__c = funraiseId,
@@ -78,9 +92,10 @@ public class frQuestion {
         
         try {
             Database.upsert(question, Question__c.Field.fr_ID__c, true);
+            result = true;
         } catch (DMLException ex) {
-            frUtil.logException(frUtil.Entity.QUESTION, funraiseId, ex);
-            return;
+            if(createLogRecord) frUtil.logException(frUtil.Entity.QUESTION, funraiseId, ex);
         }
+        return result;
     } 
 }

--- a/src/classes/frQuestionTest.cls
+++ b/src/classes/frQuestionTest.cls
@@ -141,7 +141,7 @@ public class frQuestionTest {
         System.assertEquals(countAfter, 0, 'The question should have been deleted');
     }
     
-    private static Map<String, Object> getTestRequest() {
+    public static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', 1234);
         request.put('name', 'Test Question');

--- a/src/classes/frQuestionTest.cls
+++ b/src/classes/frQuestionTest.cls
@@ -45,20 +45,12 @@ public class frQuestionTest {
         Map<String, Object> request = getTestRequest();
         request.put('id', funraiseId);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSCustomQuestionController.syncEntity();
-        
         Test.stopTest();
         frTestUtil.assertNoErrors();
+        
         Question__c question = [SELECT Id, fr_ID__c, Name__c, Description__c, Type__c
                                 FROM Question__c WHERE fr_ID__c = :funraiseId];
         
@@ -79,20 +71,12 @@ public class frQuestionTest {
         Map<String, Object> request = getTestRequest();
         request.put('id', funraiseId);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSCustomQuestionController.syncEntity();
-        
         Test.stopTest();
         frTestUtil.assertNoErrors();
+        
         Question__c question = [SELECT Id, fr_ID__c, Name__c, Description__c, Type__c
                                 FROM Question__c WHERE fr_ID__c = :funraiseId];
         
@@ -118,21 +102,10 @@ public class frQuestionTest {
         request.put('id', funraiseId);
         request.put('deleted', true);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/custom-question';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-        
         Integer countBefore = [SELECT COUNT() FROM Question__c];
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSCustomQuestionController.syncEntity();
-        
         Test.stopTest();
         frTestUtil.assertNoErrors();
         Integer countAfter = [SELECT COUNT() FROM Question__c];

--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -164,11 +164,11 @@ public with sharing class frSetupController {
 		return redirect;
 	}
 
-	private void addConfirm(String message) {
+	private static void addConfirm(String message) {
 		ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.CONFIRM, message));
 	}
 
-	private void addError(String message) {
+	private static void addError(String message) {
 		ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, message));	
 	}
 
@@ -216,6 +216,29 @@ public with sharing class frSetupController {
 			return false;
 		}
 	}
+    
+    public static void setupScheduledJobs() {
+        Set<String> activeJobs = new Set<String>();
+        for (CronTrigger activeJob : [SELECT CronJobDetail.Name FROM CronTrigger 
+                                        WHERE State NOT IN ('ERROR', 'DELETED') AND
+                                      CronJobDetail.Name IN :frSyncRequestScheduler.ALL_JOBS]) {
+			activeJobs.add(activeJob.CronJobDetail.Name);
+        }
+
+        if(!activeJobs.contains(frSyncRequestScheduler.SCHEDULED_JOB_NAME_1)) {
+            System.schedule(frSyncRequestScheduler.SCHEDULED_JOB_NAME_1, '0 0 * * * ?', new frSyncRequestScheduler());
+        }
+        if(!activeJobs.contains(frSyncRequestScheduler.SCHEDULED_JOB_NAME_2)) {
+            System.schedule(frSyncRequestScheduler.SCHEDULED_JOB_NAME_2, '0 15 * * * ?', new frSyncRequestScheduler());
+        }
+        if(!activeJobs.contains(frSyncRequestScheduler.SCHEDULED_JOB_NAME_3)) {
+            System.schedule(frSyncRequestScheduler.SCHEDULED_JOB_NAME_3, '0 30 * * * ?', new frSyncRequestScheduler());
+        }
+        if(!activeJobs.contains(frSyncRequestScheduler.SCHEDULED_JOB_NAME_4)) {
+            System.schedule(frSyncRequestScheduler.SCHEDULED_JOB_NAME_4, '0 45 * * * ?', new frSyncRequestScheduler());
+        }
+        addConfirm('Managed package jobs rescheduled');
+    }
 
 	@testVisible
 	private static List<frMapping__c> getDonorDefaults() {

--- a/src/classes/frSubscription.cls
+++ b/src/classes/frSubscription.cls
@@ -38,34 +38,47 @@
 * AUTHOR: Alex Molina
 */
 
-public class frSubscription {
+public class frSubscription extends frModel implements frSyncable {
     public static final Map<String, Schema.SObjectField> fields = 
         frSchemaUtil.getFields(Subscription__c.getSObjectType().getDescribe().getName());
-    public frSubscription(Map<String, Object> request) {
-        if (Boolean.valueOf(request.get('deleted'))) {
-            deleteSubscription(String.valueOf(request.get('id')));
-        } else {
-            create(request);
-        }
+        
+    public frSubscription(Sync_Attempt__c syncRecord){
+        super(syncRecord);
     }
     
-    public void deleteSubscription(String funraiseId) {
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+        if (Boolean.valueOf(request.get('deleted'))) {
+            result = deleteSubscription(String.valueOf(request.get('id')));
+        } else {
+            result = create(request);
+        }
+        return result;
+    }
+    
+    private Boolean deleteSubscription(String funraiseId) {
+        Boolean result = false;
         try {
             delete [SELECT id FROM Subscription__c WHERE fr_ID__c = :funraiseId];
+            result = true;
         } catch (DMLException e) {
-            frUtil.logException(frUtil.Entity.SUBSCRIPTION, funraiseId, e);
+            if(createLogRecord) frUtil.logException(frUtil.Entity.SUBSCRIPTION, funraiseId, e);
         }
+        return result;
     }
     
-    public void create(Map<String, Object> request) {
+    private Boolean create(Map<String, Object> request) {
+        Boolean result = false;
         String funraiseId = String.valueOf(request.get('id'));
         String name = String.valueOf(request.get('name'));
         String funraiseSupporterId = String.valueOf(request.get('supporterId'));
         List<Contact> contacts = [SELECT Id from Contact WHERE fr_Id__c = :funraiseSupporterId];
         if(contacts.isEmpty()) {
-            frUtil.logRelationshipError(frUtil.Entity.SUBSCRIPTION, funraiseId, 
+            if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.SUBSCRIPTION, funraiseId, 
                                         frUtil.Entity.SUPPORTER, funraiseSupporterId);
-            return;
+            return result;
         }
         
         Subscription__c subscription = new Subscription__c(
@@ -83,7 +96,7 @@ public class frSubscription {
             if (campaigns.size() > 0) {
                 subscription.Campaign_Goal__c = campaigns.get(0).Id;
             } else {
-                frUtil.logRelationshipError(frUtil.Entity.SUBSCRIPTION, funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.SUBSCRIPTION, funraiseId, 
                                             frUtil.Entity.CAMPAIGN, goalId);
             }
         }
@@ -104,19 +117,21 @@ public class frSubscription {
             String salesforceFieldName = funraiseFieldName.replaceAll(regex, replacement);
             salesforceFieldName =+ 'funraise__' + salesforceFieldName.capitalize() + '__c';
             Schema.SObjectField field = fields.get(salesforceFieldName);
-            frUtil.write(subscription, field, funraiseFieldName, request.get(funraiseFieldName), funraiseId);
+            frModel.write(subscription, field, funraiseFieldName, request.get(funraiseFieldName), funraiseId);
         }
         
         try {
             Database.upsert(subscription, Subscription__c.Field.fr_ID__c, true);
+            result = true;
         } catch (DMLException ex) {
-            frUtil.logException(frUtil.Entity.SUBSCRIPTION, funraiseId, ex);
-            return;
+            if(createLogRecord) frUtil.logException(frUtil.Entity.SUBSCRIPTION, funraiseId, ex);
+            return result;
         }
         
         if(pledgeAmount != null) {
             frPledge.create(subscription, pledgeAmount);
         }
+        return result;
     }
     
 }

--- a/src/classes/frSubscriptionTest.cls
+++ b/src/classes/frSubscriptionTest.cls
@@ -46,19 +46,11 @@ public class frSubscriptionTest {
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
         request.put('id', funraiseId);
+
+        frTestUtil.createTestPost(request);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
         Test.startTest();
-
         frWSSubscriptionController.syncEntity();
-
         Test.stopTest();
         
         Subscription__c subscription = [SELECT Id, fr_ID__c, 
@@ -115,17 +107,10 @@ public class frSubscriptionTest {
         request.put('id', funraiseId);
         request.put('campaignGoalId', testCampaign.fr_ID__c);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         Test.startTest();
-
         frWSSubscriptionController.syncEntity();
-
         Test.stopTest();
 
         Subscription__c subscription = [SELECT Id, fr_ID__c, Campaign_Goal__c FROM Subscription__c WHERE fr_ID__c = :funraiseId];
@@ -141,17 +126,10 @@ public class frSubscriptionTest {
         request.put('supporterId', testSupporter.fr_ID__c+'1');
         request.put('id', funraiseId);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
-
         frWSSubscriptionController.syncEntity();
-
         Test.stopTest();
 
         Integer subscriptions = [SELECT COUNT() FROM Subscription__c WHERE fr_ID__c = :funraiseId];
@@ -172,17 +150,10 @@ public class frSubscriptionTest {
         request.put('id', funraiseId);
         request.put('campaignGoalId', testCampaign.fr_ID__c+'1');
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+        
         Test.startTest();
-
         frWSSubscriptionController.syncEntity();
-
         Test.stopTest();
 
         Subscription__c subscription = [SELECT Id, fr_ID__c, Campaign_Goal__c FROM Subscription__c WHERE fr_ID__c = :funraiseId];
@@ -200,17 +171,10 @@ public class frSubscriptionTest {
         request.put('id', funraiseId);
         request.put('deleted', true);
 
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
+        frTestUtil.createTestPost(request);
+
         Test.startTest();
-
         frWSSubscriptionController.syncEntity();
-
         Test.stopTest();
 
         Integer matchingRecords = [SELECT COUNT() FROM Subscription__c WHERE fr_ID__c = :funraiseId];
@@ -227,18 +191,10 @@ public class frSubscriptionTest {
         request.put('id', funraiseId);
         request.put('pledgeAmount', 500);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
+        frTestUtil.createTestPost(request);
 
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
         Test.startTest();
-
         frWSSubscriptionController.syncEntity();
-
         Test.stopTest();
         
         Subscription__c subscription = [SELECT Id, Supporter__c FROM Subscription__c WHERE fr_ID__c = :funraiseId];

--- a/src/classes/frSubscriptionTest.cls
+++ b/src/classes/frSubscriptionTest.cls
@@ -38,7 +38,7 @@
  * AUTHOR: Alex Molina
  */
 @isTest
-public class frSubscriptionTest {  
+public class frSubscriptionTest {
     static testMethod void createSubscription_noCampaign() {
         Contact testSupporter = frDonorTest.getTestContact();
                 
@@ -96,7 +96,7 @@ public class frSubscriptionTest {
         System.assertEquals(String.valueOf(request.get('paymentMethodType')), subscription.Payment_Method_Type__c, 'The property should be what was provided in the request');
         System.assertEquals(String.valueOf(request.get('status')), subscription.Status__c, 'The property should be what was provided in the request');
         List<Object> requestPaymentDate = (List<Object>)request.get('nextPaymentDate');
-        System.assertEquals(frUtil.convertFromLocalDate(requestPaymentDate), subscription.Next_Payment_Date__c, 'The property for next payment date should be what was provided in the request');
+        System.assertEquals(frModel.convertFromLocalDate(requestPaymentDate), subscription.Next_Payment_Date__c, 'The property for next payment date should be what was provided in the request');
         
         System.assertEquals(testSupporter.Id, subscription.Supporter__c, 'The lookup for supporter should have been populated with the contact that has the funraise id referenced in the request');
         System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
@@ -114,14 +114,23 @@ public class frSubscriptionTest {
         request.put('supporterId', testSupporter.fr_ID__c);
         request.put('id', funraiseId);
         request.put('campaignGoalId', testCampaign.fr_ID__c);
-
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frSubscription(request);
+
+        frWSSubscriptionController.syncEntity();
+
         Test.stopTest();
 
         Subscription__c subscription = [SELECT Id, fr_ID__c, Campaign_Goal__c FROM Subscription__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(testCampaign.Id, subscription.Campaign_Goal__c, 'The subscription should have been assocaited with the campaign goal included in the request');
-        System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
+        frTestUtil.assertNoErrors();
     }
     
     static testMethod void createSubscription_missingSupporter() {	
@@ -132,13 +141,22 @@ public class frSubscriptionTest {
         request.put('supporterId', testSupporter.fr_ID__c+'1');
         request.put('id', funraiseId);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frSubscription(request);
+
+        frWSSubscriptionController.syncEntity();
+
         Test.stopTest();
 
         Integer subscriptions = [SELECT COUNT() FROM Subscription__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(0, subscriptions, 'Since the supporter could not be found, the subscription should not have been created');
-        System.assertEquals(1, [SELECT COUNT() FROM Error__c], 'There should be an error for a missing supporter');
+        System.assertEquals(1, [SELECT COUNT() FROM Sync_Attempt__c], 'There should be a sync attempt to retry the failed sync');
     }
     
     static testMethod void createSubscription_missingCampaignGoal() {	
@@ -154,13 +172,21 @@ public class frSubscriptionTest {
         request.put('id', funraiseId);
         request.put('campaignGoalId', testCampaign.fr_ID__c+'1');
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frSubscription(request);
+
+        frWSSubscriptionController.syncEntity();
+
         Test.stopTest();
 
         Subscription__c subscription = [SELECT Id, fr_ID__c, Campaign_Goal__c FROM Subscription__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(null, subscription.Campaign_Goal__c, 'The subscription should not have been associated with a campaign since the requested id does not exist');
-        System.assertEquals(1, [SELECT COUNT() FROM Error__c], 'There should be an error for a missing campaign record');
     }
     
     static testMethod void deleteSubscription() {	      
@@ -174,8 +200,17 @@ public class frSubscriptionTest {
         request.put('id', funraiseId);
         request.put('deleted', true);
 
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/fundraising-event';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
         Test.startTest();
-        new frSubscription(request);
+
+        frWSSubscriptionController.syncEntity();
+
         Test.stopTest();
 
         Integer matchingRecords = [SELECT COUNT() FROM Subscription__c WHERE fr_ID__c = :funraiseId];
@@ -214,7 +249,7 @@ public class frSubscriptionTest {
         System.assertEquals(500, pledge.Pledge_Amount__c, 'The pledge amount should have been what was received in the request');
     }
     
-    private static Map<String, Object> getTestRequest() {
+    public static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('name', '000001');
         request.put('status', 'Active');

--- a/src/classes/frSyncRequestHandler.cls
+++ b/src/classes/frSyncRequestHandler.cls
@@ -1,0 +1,74 @@
+public class frSyncRequestHandler implements Database.Batchable<SObject> {
+    public static final Integer MAX_ATTEMPTS = 3;
+    public Database.QueryLocator start(Database.BatchableContext bc) {
+        Id jobId = bc.getJobId();
+		Id classId = [SELECT ApexClassId FROM AsyncApexJob WHERE id = :jobId][0].ApexClassId;
+        Integer otherRunningJobs = [SELECT count() FROM AsyncApexJob WHERE 
+                                      JobType = 'BatchApex'
+                                      AND Id != :jobId 
+                                      AND Status = 'Processing' 
+                                      AND ApexClassId = :classId 
+                                      ];
+        if (otherRunningJobs > 0) {
+            //return an empty query locator (with limit 0) to basically no-op
+            return Database.getQueryLocator([SELECT Id FROM Sync_Attempt__c LIMIT 0]);
+        } else {
+            return Database.getQueryLocator([SELECT Id, Request_Body__c, Attempts__c, Type__c FROM Sync_Attempt__c ORDER BY CreatedDate]);
+        }
+    }
+    
+    public void execute (Database.BatchableContext bc, List<Sync_Attempt__c> syncs) {
+        List<Sync_Attempt__c> toDelete = new List<Sync_Attempt__c>();
+        List<Sync_Attempt__c> toUpdate = new List<Sync_Attempt__c>();
+        for (Sync_Attempt__c attempt : syncs) {
+            attempt.Attempts__c += 1;
+            Boolean success = sync(attempt);
+            if (success || attempt.Attempts__c > MAX_ATTEMPTS) {
+                toDelete.add(attempt);
+            } else {
+                toUpdate.add(attempt);
+            }
+        }
+        delete toDelete;
+        update toUpdate;
+    }
+    
+    public static Boolean sync(Sync_Attempt__c attempt) {
+        Boolean result = false;
+        frSyncable syncInstance = getSyncInstance(attempt);
+        result = syncInstance.sync();
+        return result;
+    }
+    
+    private static frSyncable getSyncInstance(Sync_Attempt__c attempt) {
+        frSyncable result = null;
+        if(attempt.Type__c == frUtil.Entity.DONATION.name()) {
+            result = new frDonation(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.SUPPORTER.name()) {
+            result = new frDonor(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.EVENT.name()) {
+            result = new frFundraisingEvent(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.REGISTRATION.name()) {
+            result = new frFundraisingEventRegistration(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.SUBSCRIPTION.name()) {
+            result = new frSubscription(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.CAMPAIGN.name()) {
+            result = new frCampaign(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.EMAIL.name()) {
+            result = new frDonorEmails(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.TASK.name()) {
+            result = new frTask(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.QUESTION.name()) {
+            result = new frQuestion(attempt);
+        } else if (attempt.Type__c == frUtil.Entity.ANSWER.name()) {
+            result = new frAnswer(attempt);
+        } else {
+            System.debug('Funraise was not able to find the correct object to attempt to resync, type:' + attempt.Type__c);
+        }
+        return result;
+    }
+    
+    public void finish(Database.BatchableContext bc) {
+        
+    }
+}

--- a/src/classes/frSyncRequestHandler.cls
+++ b/src/classes/frSyncRequestHandler.cls
@@ -20,17 +20,24 @@ public class frSyncRequestHandler implements Database.Batchable<SObject> {
     public void execute (Database.BatchableContext bc, List<Sync_Attempt__c> syncs) {
         List<Sync_Attempt__c> toDelete = new List<Sync_Attempt__c>();
         List<Sync_Attempt__c> toUpdate = new List<Sync_Attempt__c>();
-        for (Sync_Attempt__c attempt : syncs) {
-            attempt.Attempts__c += 1;
-            Boolean success = sync(attempt);
-            if (success || attempt.Attempts__c > MAX_ATTEMPTS) {
-                toDelete.add(attempt);
-            } else {
-                toUpdate.add(attempt);
-            }
+        try {
+            for (Sync_Attempt__c attempt : syncs) {
+                attempt.Attempts__c += 1;
+                Boolean success = false;
+                try {
+                    success = sync(attempt);
+                } finally {
+                    if (success || attempt.Attempts__c > MAX_ATTEMPTS) {
+                        toDelete.add(attempt);
+                    } else {
+                        toUpdate.add(attempt);
+                    }
+                }
+            }  
+        } finally {
+            delete toDelete;
+            update toUpdate; 
         }
-        delete toDelete;
-        update toUpdate;
     }
     
     public static Boolean sync(Sync_Attempt__c attempt) {

--- a/src/classes/frSyncRequestHandler.cls-meta.xml
+++ b/src/classes/frSyncRequestHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frSyncRequestHandlerTest.cls
+++ b/src/classes/frSyncRequestHandlerTest.cls
@@ -1,0 +1,107 @@
+/*
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:
+*
+*
+*
+* CREATED: 2021 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
+@isTest
+public class frSyncRequestHandlerTest {
+    static testMethod void testProcessAllTypes() {
+        List<Sync_Attempt__c> attempts = new List<Sync_Attempt__c>();
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frAnswerTest.getTestRequest()),
+            Type__c = frUtil.Entity.ANSWER.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frCampaignTest.getTestRequest()),
+            Type__c = frUtil.Entity.CAMPAIGN.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frDonationTest.getTestRequest()),
+            Type__c = frUtil.Entity.DONATION.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frDonorTest.getTestRequest()),
+            Type__c = frUtil.Entity.SUPPORTER.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frDonorEmailsTest.getTestRequest()),
+            Type__c = frUtil.Entity.EMAIL.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frFundraisingEventRegistrationTest.getTestRequest()),
+            Type__c = frUtil.Entity.REGISTRATION.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frFundraisingEventTest.getTestRequest()),
+            Type__c = frUtil.Entity.EVENT.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frQuestionTest.getTestRequest()),
+            Type__c = frUtil.Entity.QUESTION.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frSubscriptionTest.getTestRequest()),
+            Type__c = frUtil.Entity.SUBSCRIPTION.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frSubscriptionTest.getTestRequest()),
+            Type__c = frUtil.Entity.SUBSCRIPTION.name(),
+            Attempts__c = 1
+        ));
+        attempts.add(new Sync_Attempt__c(
+        	Request_Body__c = Json.serialize(frWSTaskControllerTest.getTestRequest()),
+            Type__c = frUtil.Entity.TASK.name(),
+            Attempts__c = 1
+        ));
+        
+        insert attempts;
+        
+        Test.startTest();
+        frSyncRequestHandler handler = new frSyncRequestHandler();
+        Database.executeBatch(handler);
+        Test.stopTest();
+    }
+}

--- a/src/classes/frSyncRequestHandlerTest.cls-meta.xml
+++ b/src/classes/frSyncRequestHandlerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frSyncRequestScheduler.cls
+++ b/src/classes/frSyncRequestScheduler.cls
@@ -1,0 +1,10 @@
+global class frSyncRequestScheduler implements Schedulable {
+    public static final String SCHEDULED_JOB_NAME_1 = 'Funraise Sync 1';
+    public static final String SCHEDULED_JOB_NAME_2 = 'Funraise Sync 2';
+    public static final String SCHEDULED_JOB_NAME_3 = 'Funraise Sync 3';
+    public static final String SCHEDULED_JOB_NAME_4 = 'Funraise Sync 4';
+    public static final Set<String> ALL_JOBS = new Set<String>{SCHEDULED_JOB_NAME_1, SCHEDULED_JOB_NAME_2, SCHEDULED_JOB_NAME_3, SCHEDULED_JOB_NAME_4};
+    global void execute(SchedulableContext sc){
+        Database.executeBatch(new frSyncRequestHandler(), 50);
+    }
+}

--- a/src/classes/frSyncRequestScheduler.cls-meta.xml
+++ b/src/classes/frSyncRequestScheduler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frSyncable.cls
+++ b/src/classes/frSyncable.cls
@@ -1,0 +1,3 @@
+public interface frSyncable {
+    Boolean sync();
+}

--- a/src/classes/frSyncable.cls-meta.xml
+++ b/src/classes/frSyncable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frTask.cls
+++ b/src/classes/frTask.cls
@@ -1,0 +1,109 @@
+/*
+*
+*  Copyright (c) 2020, Funraise Inc
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*  1. Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*  2. Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in the
+*     documentation and/or other materials provided with the distribution.
+*  3. All advertising materials mentioning features or use of this software
+*     must display the following acknowledgement:
+*     This product includes software developed by the <organization>.
+*  4. Neither the name of the <organization> nor the
+*     names of its contributors may be used to endorse or promote products
+*     derived from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY FUNRAISE INC ''AS IS'' AND ANY
+*  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL FUNRAISE INC BE LIABLE FOR ANY
+*  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*
+*
+* PURPOSE:
+*
+*
+*
+* CREATED: 2021 Funraise Inc - https://funraise.io
+* AUTHOR: Alex Molina
+*/
+
+public class frTask extends frModel implements frSyncable {   
+    public frTask(Sync_Attempt__c syncRecord){
+        super(syncRecord);
+    }
+    
+    public Boolean sync() {
+        Boolean result = false;
+        Map<String, Object> request = 
+            (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
+       
+        String frTaskId = String.valueOf(request.get('id'));
+        
+        Boolean isDeleted = Boolean.valueOf(request.get('deleted'));
+        if(isDeleted){
+            delete [SELECT Id FROM Task WHERE fr_Task_ID__c = :frTaskId];
+            result = true;
+            return result;
+        }
+        
+        String donorId = String.valueOf(request.get('donorId'));
+        List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c from Contact where fr_ID__c = :donorId');
+        if(contacts.isEmpty()){
+            if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.TASK, frTaskId, 
+                                        frUtil.Entity.SUPPORTER, donorId);
+            return result;
+        }
+
+        
+        Task sfTask = new Task(fr_Task_Id__c = frTaskId, Priority = 'Normal', WhoId = contacts.get(0).Id);
+        
+        String donationId = String.valueOf(request.get('donationId'));
+        if(donationId != null){ 
+            List<Opportunity> opportunities = [SELECT Id, fr_Id__c FROM Opportunity WHERE fr_Id__c = :donationId];            
+            if(!opportunities.isEmpty()){
+                sfTask.WhatId = opportunities.get(0).Id;
+            } else {
+                if(createLogRecord) frUtil.logRelationshipError(frUtil.Entity.TASK, frTaskId, 
+                                            frUtil.Entity.DONATION, donationId);
+            }
+        }
+
+        String actionRequired = String.valueOf(request.get('actionRequired'));
+        sfTask.Subject = actionRequired;
+        
+        String frType = String.valueOf(request.get('taskType'));
+        if(String.isBlank(sfTask.Subject)) {
+            sfTask.Subject = frType;
+        }
+        
+        sfTask.Description = String.valueOf(request.get('description'));
+        sfTask.ActivityDate = DateTime.newInstance((Long)request.get('createdDate')).dateGMT();
+        
+        String frStatus = String.valueOf(request.get('status'));
+        if(frStatus == 'Complete' || frType == 'Interaction'){
+            sfTask.Status = 'Completed';
+            sfTask.ActivityDate = DateTime.newInstance((Long)request.get('completedDate')).dateGMT();
+        } else if(frStatus == 'Pending' || frStatus == 'Canceled'){
+            sfTask.Status = 'Not Started';
+        }
+        
+        try {
+            upsert sfTask Task.Fields.fr_Task_ID__c;
+            result = true;
+        } catch (DMLException ex) {
+            if(createLogRecord) frUtil.logException(frUtil.Entity.TASK, frTaskId, ex);
+        }
+        return result;
+    }
+}

--- a/src/classes/frTask.cls-meta.xml
+++ b/src/classes/frTask.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frUtil.cls
+++ b/src/classes/frUtil.cls
@@ -12,82 +12,12 @@ public class frUtil {
         }
     }
     
-    public static DateTime convertFromLocalDateTime(List<Object> localDateTime) {
-        return DateTime.newInstance(
-            (Integer)localDateTime.get(0), //year
-            (Integer)localDateTime.get(1), //month
-            (Integer)localDateTime.get(2), //day
-            (Integer)localDateTime.get(3), //hour
-            (Integer)localDateTime.get(4), //minute
-            0 				  //second
-        );
-    }
-    
-    public static Date convertFromLocalDate(List<Object> localDate) {
-        return Date.newInstance(
-            (Integer)localDate.get(0), //year
-            (Integer)localDate.get(1), //month
-            (Integer)localDate.get(2)  //day
-        );
-    }
-    
-    public static void write(SObject record, Schema.SObjectField field, String fieldName, Object value, String funraiseId) {
-        try {
-            if (fieldName.toLowerCase() == 'id') {
-                if (value != null && ((String)value) != '') {
-                    record.put(field, Id.valueOf((String)value));
-                }
-            } else if (field.getDescribe().getType() == Schema.DisplayType.DateTime) {
-                record.put(field, DateTime.newInstance((Long)value));
-            } else if (field.getDescribe().getType() == Schema.DisplayType.Date) {
-                if(value instanceof List<Object>) {
-                    List<Object> localDate = (List<Object>)value;
-                    if(localDate.size() > 3) {
-                        DateTime sfLocalDateTime = convertFromLocalDateTime(localDate);
-                        record.put(field, sfLocalDateTime);                        
-                    } else if (localDate.size() == 3) {
-                        Date sfLocalDate = convertFromLocalDate(localDate);
-                        record.put(field, sfLocalDate);                        
-                    }
-                    
-                } else {
-                    record.put(field, DateTime.newInstance((Long)value).date());
-                }
-            } else if(field.getDescribe().getType() == Schema.DisplayType.Double) {
-                record.put(field, Double.valueOf(value));
-            } else if(field.getDescribe().getType() == Schema.DisplayType.Integer) {
-                record.put(field, Integer.valueOf(value));
-            } else if(field.getDescribe().getType() == Schema.DisplayType.Percent) {
-                record.put(field, Decimal.valueOf(String.valueOf(value)));
-            } else {
-                write(record, field, value, funraiseId);
-            }
-        }
-        catch (Exception e) {
-            write(record, field, value, funraiseId);
-        }
-    }
-    
-    private static void write(SObject record, Schema.SObjectField field, Object value, String funraiseId) {
-        try {
-            if(value instanceof String) {
-                value = truncateToFieldLength(field.getDescribe(), (String)value);
-            }
-            record.put(field, value);
-        } catch (Exception ex) {
-            insert new Error__c(Error__c = 'Field mapping exception. Object type: '+ record.getSObjectType().getDescribe().getName()
-                +' Record Id: '+record.Id+' - Funraise Id: '+ funraiseId + ' - Field: '+field.getDescribe().getName()+' - Value: '+value
-                +' Exception: '+ex
-            );
-        }
-    }
-    
     public static void logRelationshipError(Entity errObject, String recordId, Entity missingRelationship, String relationshipId) {
         logRelationshipError(errObject, recordId, missingRelationship, relationshipId, null);
     }
     
     public static void logRelationshipError(Entity errObject, String recordId, Entity missingRelationship, String relationshipId, String optionalError) {
-        String relationshipObject = getErrorObjectFromEnum(missingRelationship);
+        String relationshipObject = getObjectFromEnum(missingRelationship);
         String error = 'Failed to find related record ' + 
                  relationshipObject + ' with Funraise Id: ' + relationshipId;
         if(optionalError != null) {
@@ -98,7 +28,7 @@ public class frUtil {
     
     private static Set<StatusCode> duplicateValueStatusCodes = 
         new Set<StatusCode>{StatusCode.DUPLICATE_EXTERNAL_ID, StatusCode.DUPLICATE_VALUE};
-            
+    
     public static void logException(Entity errObject, String recordId, Exception ex) {
         if(ex instanceof DMLException) {
             DMLException dmlEx = (DMLException)ex;
@@ -115,7 +45,7 @@ public class frUtil {
     }
     
     public static void logError(Entity errObject, String recordId, String error) {
-		String funraiseObject = getErrorObjectFromEnum(errObject);
+		String funraiseObject = getObjectFromEnum(errObject);
         insert new Error__c(
         	Error__c = error,
             Funraise_Object__c = funraiseObject,
@@ -123,7 +53,7 @@ public class frUtil {
         );
     }
     
-    private static String getErrorObjectFromEnum(Entity frObject) {
+    private static String getObjectFromEnum(Entity frObject) {
         String funraiseObject = null;
         if(frObject == Entity.DONATION) {
             funraiseObject = 'Transaction';

--- a/src/classes/frWSBaseController.cls
+++ b/src/classes/frWSBaseController.cls
@@ -34,15 +34,21 @@
  *
  *
  *
- * CREATED: 2016 Funraise Inc - https://funraise.io
- * AUTHOR: Jason M. Swenski
+ * CREATED: 2021 Funraise Inc - https://funraise.io
+ * AUTHOR: Alex Molina
  */
 
-@RestResource(urlMapping='/v1/donor')
-global with sharing class frWSDonorController {
-
-    @HttpPost
-    global static void syncEntity() {
-        frWSBaseController.syncEntity(frUtil.Entity.SUPPORTER);
+public class frWSBaseController {
+    
+    public static void syncEntity(frUtil.Entity entity) {
+        Sync_Attempt__c syncRecord = new Sync_Attempt__c(
+        	Request_Body__c = RestContext.request.requestBody.toString(),
+            Type__c = entity.name(),
+            Attempts__c = 1
+        );
+        Boolean success = frSyncRequestHandler.sync(syncRecord);
+        if (!success) {
+            insert syncRecord;
+        }
     }
 }

--- a/src/classes/frWSBaseController.cls-meta.xml
+++ b/src/classes/frWSBaseController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frWSCampaignController.cls
+++ b/src/classes/frWSCampaignController.cls
@@ -43,7 +43,6 @@ global with sharing class frWSCampaignController {
     
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frCampaign campaign = new frCampaign(request);
+        frWSBaseController.syncEntity(frUtil.Entity.CAMPAIGN);
     }
 }

--- a/src/classes/frWSCustomQuestionAnswerController.cls
+++ b/src/classes/frWSCustomQuestionAnswerController.cls
@@ -43,7 +43,6 @@ global with sharing class frWSCustomQuestionAnswerController {
     
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frAnswer answer = new frAnswer(request);
+        frWSBaseController.syncEntity(frUtil.Entity.ANSWER);
     }
 }

--- a/src/classes/frWSCustomQuestionController.cls
+++ b/src/classes/frWSCustomQuestionController.cls
@@ -43,7 +43,6 @@ global with sharing class frWSCustomQuestionController {
     
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frQuestion question = new frQuestion(request);
+        frWSBaseController.syncEntity(frUtil.Entity.QUESTION);
     }
 }

--- a/src/classes/frWSDonationController.cls
+++ b/src/classes/frWSDonationController.cls
@@ -43,18 +43,6 @@ global with sharing class frWSDonationController {
 
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frDonation donation = new frDonation(request);
-        
-        if (donation.hasDonor()) {
-        	donation.createOpportunityMapping(request);
-        }
-
-        Map<String,Object> resp = new Map<String,Object>();
-        resp.put('id', donation.getOpportunityId());
-
-        RestContext.response.addHeader('Content-Type', 'application/json');
-        RestContext.response.responseBody = Blob.valueOf(JSON.serialize(resp));
-
+        frWSBaseController.syncEntity(frUtil.Entity.DONATION);
     }
 }

--- a/src/classes/frWSDonorEmailController.cls
+++ b/src/classes/frWSDonorEmailController.cls
@@ -42,13 +42,6 @@ global with sharing class frWSDonorEmailController {
 
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        String emailId = frDonorEmails.create(request);
-
-        Map<String,Object> resp = new Map<String,Object>();
-        resp.put('id', emailId);
-
-        RestContext.response.addHeader('Content-Type', 'application/json');
-        RestContext.response.responseBody = Blob.valueOf(JSON.serialize(resp));
+        frWSBaseController.syncEntity(frUtil.Entity.EMAIL);
     }
 }

--- a/src/classes/frWSFundraisingEventController.cls
+++ b/src/classes/frWSFundraisingEventController.cls
@@ -43,7 +43,6 @@ global with sharing class frWSFundraisingEventController {
     
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frFundraisingEvent event = new frFundraisingEvent(request);
+        frWSBaseController.syncEntity(frUtil.Entity.EVENT);
     }
 }

--- a/src/classes/frWSFundraisingEventRegistrationCntrlr.cls
+++ b/src/classes/frWSFundraisingEventRegistrationCntrlr.cls
@@ -43,7 +43,6 @@ global with sharing class frWSFundraisingEventRegistrationCntrlr {
     
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frFundraisingEventRegistration registration = new frFundraisingEventRegistration(request);
+        frWSBaseController.syncEntity(frUtil.Entity.REGISTRATION);
     }
 }

--- a/src/classes/frWSSubscriptionController.cls
+++ b/src/classes/frWSSubscriptionController.cls
@@ -43,7 +43,6 @@ global with sharing class frWSSubscriptionController {
     
     @HttpPost
     global static void syncEntity() {
-        Map<String, Object> request = (Map<String, Object>)JSON.deserializeUntyped(RestContext.request.requestBody.toString());
-        frSubscription subscription = new frSubscription(request);
+        frWSBaseController.syncEntity(frUtil.Entity.SUBSCRIPTION);
     }
 }

--- a/src/classes/frWSTaskControllerTest.cls
+++ b/src/classes/frWSTaskControllerTest.cls
@@ -39,10 +39,11 @@
 */
 @isTest
 public class frWSTaskControllerTest {
-    static testMethod void syncEntity_test() {
-        insert new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'testExisting@example.com', fr_ID__c = '410');
-        insert new Opportunity(fr_ID__c = '67', StageName = 'Closed Won', Name = 'donation1', CloseDate = Date.today());
-        insert new Opportunity(fr_ID__c = '68', StageName = 'Closed Won', Name = 'donation2', CloseDate = Date.today());
+    static testMethod void syncEntity_task() {
+        Contact supporter = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'testExisting@example.com', fr_ID__c = '410');
+		Opportunity donation = new Opportunity(fr_ID__c = '67', StageName = 'Closed Won', Name = 'donation1', CloseDate = Date.today());
+        Opportunity unrelatedDonation = new Opportunity(fr_ID__c = '68', StageName = 'Closed Won', Name = 'donation2', CloseDate = Date.today());
+        insert new List<SObject>{supporter, donation, unrelatedDonation};
         
         RestRequest req = new RestRequest();
         RestResponse res = new RestResponse();
@@ -59,29 +60,143 @@ public class frWSTaskControllerTest {
         
         Test.stopTest();
         
-        Map<String, Object> response = (Map<String, Object>)JSON.deserializeUntyped(
-            res.responseBody.toString()
-        );
+        List<Task> expectedTasks = [SELECT Id, WhoId, WhatId FROM Task WHERE fr_Task_ID__c = '856'];
+        System.assertEquals(1, expectedTasks.size(), 'An unexpected number of tasks were returned');
+        Task expectedTask = expectedTasks.get(0);
+        System.assertEquals(expectedTask.WhoId, supporter.Id, 'The task was not related to the correct supporter');
+        System.assertEquals(expectedTask.WhatId, donation.Id, 'The task was not related to the correct opportunity');
+    }
+    
+    static testMethod void syncEntity_interaction() {
+        Contact supporter = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'testExisting@example.com', fr_ID__c = '410');
+        insert supporter;
         
-        Boolean success = (Boolean)response.get('success');
-        System.assert(success, 'task update failed');
+        Map<String, Object> request = getTestRequest();
+        request.put('taskType', 'Interaction');
+        request.remove('donationId');
         
-        String message = (String)response.get('message');
-        System.assertEquals('', message, 'error message on update');
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+        
+        Test.startTest();
+        
+        frWSTaskController.syncEntity();
+        
+        Test.stopTest();
+        
+        List<Task> expectedTasks = [SELECT Id, WhoId, WhatId FROM Task WHERE fr_Task_ID__c = '856'];
+        System.assertEquals(1, expectedTasks.size(), 'An unexpected number of tasks were returned');
+        Task expectedTask = expectedTasks.get(0);
+        System.assertEquals(expectedTask.WhoId, supporter.Id, 'The interaction was not related to the correct supporter');
+    }
+
+    static testMethod void syncEntity_missingSupporter() {
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(getTestPayload());
+        RestContext.request = req;
+        RestContext.response = res;
+        
+        Test.startTest();
+        
+        frWSTaskController.syncEntity();
+        
+        Test.stopTest();
+        
+        Integer resultingTasks = [SELECT COUNT() FROM Task WHERE fr_Task_ID__c != null];
+        System.assertEquals(0, resultingTasks, 'A task should not have been created if the supporter/contact could not be found');
+    }
+    
+    static testMethod void syncEntity_testDelete() {
+        Contact supporter = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'testExisting@example.com', fr_ID__c = '410');
+		Opportunity donation = new Opportunity(fr_ID__c = '67', StageName = 'Closed Won', Name = 'donation1', CloseDate = Date.today());
+        insert new List<SObject>{supporter, donation};
+            
+        Task existingTask = new Task(fr_Task_Id__c = '856', Description = 'Test Task', Priority = 'Normal', WhoId = supporter.Id,
+                                    WhatId = donation.Id);
+        insert existingTask;
+
+        Map<String, Object> request = getTestRequest();
+        request.put('deleted', true);
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+        
+        Test.startTest();
+        
+        frWSTaskController.syncEntity();
+        
+        Test.stopTest();
+        
+        Integer expectedTasks = [SELECT COUNT() FROM Task WHERE fr_Task_ID__c = :existingTask.fr_Task_Id__c];
+        System.assertEquals(0, expectedTasks, 'The task should have been deleted');
+    }
+    
+    
+    
+    static testMethod void syncEntity_testDelete_notFound() {
+        Contact supporter = new Contact(LastName = 'Test', FirstName = 'Existing', Email = 'testExisting@example.com', fr_ID__c = '410');
+		Opportunity donation = new Opportunity(fr_ID__c = '67', StageName = 'Closed Won', Name = 'donation1', CloseDate = Date.today());
+        insert new List<SObject>{supporter, donation};
+            
+        Task existingTask = new Task(fr_Task_Id__c = '111', Description = 'Test Task', Priority = 'Normal', WhoId = supporter.Id,
+                                    WhatId = donation.Id);
+        insert existingTask;
+
+        Map<String, Object> request = getTestRequest();
+        request.put('id', 222); //different from request, won't be found. nothing should be deleted
+        request.put('deleted', true);
+        
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+        
+        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(Json.serialize(request));
+        RestContext.request = req;
+        RestContext.response = res;
+        
+        Test.startTest();
+        
+        frWSTaskController.syncEntity();
+        
+        Test.stopTest();
+        
+        Integer expectedTasks = [SELECT COUNT() FROM Task WHERE fr_Task_ID__c = :existingTask.fr_Task_Id__c];
+        System.assertEquals(1, expectedTasks, 'The existing task should NOT have been deleted');
+    }
+    
+    public static Map<String, Object> getTestRequest() {
+        Map<String, Object> request = new Map<String, Object>();
+        request.put('id', 856);
+        request.put('status', 'Pending');
+        request.put('donationId', 67);
+        request.put('donorId', 410);
+        request.put('description', 'Test description');
+        request.put('taskType', 'Activity');
+        request.put('createdDate', 1493077510493L);
+        request.put('updtime', 1487801043934L);
+        request.put('completedDate', 1487801043597L);
+        request.put('deleted', false);
+        return request;
     }
     
     private static String getTestPayload() {
-        
-        return '{'+
-                '"id":856,'+
-                '"status":"Pending",'+
-                '"donationId":67,'+
-                '"donorId":410,'+
-                '"description":"Test description",'+
-                '"taskType":"Activity",'+
-                '"createdDate":1493077510493,'+
-                '"updtime":1487801043934,'+
-                '"completedDate":1487801043597'+
-            '}';
+        return Json.serialize(getTestRequest());
     }
 }

--- a/src/classes/frWSTaskControllerTest.cls
+++ b/src/classes/frWSTaskControllerTest.cls
@@ -45,19 +45,9 @@ public class frWSTaskControllerTest {
         Opportunity unrelatedDonation = new Opportunity(fr_ID__c = '68', StageName = 'Closed Won', Name = 'donation2', CloseDate = Date.today());
         insert new List<SObject>{supporter, donation, unrelatedDonation};
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-        
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
         frWSTaskController.syncEntity();
-        
         Test.stopTest();
         
         List<Task> expectedTasks = [SELECT Id, WhoId, WhatId FROM Task WHERE fr_Task_ID__c = '856'];
@@ -75,19 +65,9 @@ public class frWSTaskControllerTest {
         request.put('taskType', 'Interaction');
         request.remove('donationId');
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSTaskController.syncEntity();
-        
         Test.stopTest();
         
         List<Task> expectedTasks = [SELECT Id, WhoId, WhatId FROM Task WHERE fr_Task_ID__c = '856'];
@@ -97,19 +77,9 @@ public class frWSTaskControllerTest {
     }
 
     static testMethod void syncEntity_missingSupporter() {
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(getTestPayload());
-        RestContext.request = req;
-        RestContext.response = res;
-        
+        frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
-        
         frWSTaskController.syncEntity();
-        
         Test.stopTest();
         
         Integer resultingTasks = [SELECT COUNT() FROM Task WHERE fr_Task_ID__c != null];
@@ -128,19 +98,9 @@ public class frWSTaskControllerTest {
         Map<String, Object> request = getTestRequest();
         request.put('deleted', true);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSTaskController.syncEntity();
-        
         Test.stopTest();
         
         Integer expectedTasks = [SELECT COUNT() FROM Task WHERE fr_Task_ID__c = :existingTask.fr_Task_Id__c];
@@ -159,22 +119,12 @@ public class frWSTaskControllerTest {
         insert existingTask;
 
         Map<String, Object> request = getTestRequest();
-        request.put('id', 222); //different from request, won't be found. nothing should be deleted
+        request.put('id', 222); //different from existing, won't be found. nothing should be deleted
         request.put('deleted', true);
         
-        RestRequest req = new RestRequest();
-        RestResponse res = new RestResponse();
-        
-        req.requestURI = 'https://XXXX.salesforce.com/services/apexrest/funraise/v1/task';
-        req.httpMethod = 'POST';
-        req.requestBody = Blob.valueOf(Json.serialize(request));
-        RestContext.request = req;
-        RestContext.response = res;
-        
+        frTestUtil.createTestPost(request);
         Test.startTest();
-        
         frWSTaskController.syncEntity();
-        
         Test.stopTest();
         
         Integer expectedTasks = [SELECT COUNT() FROM Task WHERE fr_Task_ID__c = :existingTask.fr_Task_Id__c];
@@ -194,9 +144,5 @@ public class frWSTaskControllerTest {
         request.put('completedDate', 1487801043597L);
         request.put('deleted', false);
         return request;
-    }
-    
-    private static String getTestPayload() {
-        return Json.serialize(getTestRequest());
     }
 }

--- a/src/package.xml
+++ b/src/package.xml
@@ -21,6 +21,8 @@
         <members>frModel</members>
         <members>frOpportunityPledgeCalculatorTriggerTest</members>
         <members>frPledge</members>
+        <members>frPostInstall</members>
+        <members>frPostInstallTest</members>
         <members>frQuestion</members>
         <members>frQuestionTest</members>
         <members>frSchemaUtil</members>
@@ -28,7 +30,13 @@
         <members>frSetupControllerTest</members>
         <members>frSubscription</members>
         <members>frSubscriptionTest</members>
+        <members>frSyncRequestHandler</members>
+        <members>frSyncRequestHandlerTest</members>
+        <members>frSyncRequestScheduler</members>
+        <members>frSyncable</members>
+        <members>frTask</members>
         <members>frUtil</members>
+        <members>frWSBaseController</members>
         <members>frWSCampaignController</members>
         <members>frWSCustomQuestionAnswerController</members>
         <members>frWSCustomQuestionController</members>

--- a/src/pages/frSetup.page
+++ b/src/pages/frSetup.page
@@ -109,5 +109,13 @@
 			</apex:commandLink>
 		</apex:pageBlockSection>
 	</apex:pageBlock>
+        <apex:pageBlock title="Scheduled Job Maintenance">
+		<apex:pageBlockButtons location="top">
+			<apex:commandButton action="{!setupScheduledJobs}" value="Reschedule Jobs" />
+		</apex:pageBlockButtons>
+		<h2>
+		The scheduled job(s) for the Funraise Managed Package are automatically created.  If you need to rescheduled these jobs, click the above button
+		</h2>
+	</apex:pageBlock>
 	</apex:form>
 </apex:page>


### PR DESCRIPTION
Only on the final attempt adding error logs for user debugging.

This can help address situations where the failures are caused by race conditions or time-based issues where a record is locked.  Scheduled jobs will pick up the record of the sync and retry before generating errors to the user