### PR TITLE
Allow configuration of resolution for existing data in field mapping

### DIFF
--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -42,7 +42,7 @@ public class frDonation extends frModel implements frSyncable {
     public static List<frMapping__c> mappings {
         get {
             if(mappings == null) {
-                mappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Type__c FROM frMapping__c WHERE Type__c = :TYPE ORDER BY CreatedDate];
+                mappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :TYPE ORDER BY CreatedDate];
             }
             return mappings;
         }
@@ -180,7 +180,7 @@ public class frDonation extends frModel implements frSyncable {
         Map<String, Contact> relatedContacts = new Map<String, Contact>();
         Set<String> supportersWithContactRoles = new Set<String>();
         for(Contact relatedContact : [SELECT Id, fr_Id__c, 
-                                      (SELECT Id, Role, ContactId FROM OpportunityContactRoles WHERE OpportunityId = :getOpportunityId()) 
+                                      (SELECT Id, Role, ContactId FROM OpportunityContactRoles WHERE OpportunityId = :getSalesforceId()) 
                                       from Contact WHERE fr_Id__c IN :relatedSupporterFunraiseIds]) {
                                           relatedContacts.put(relatedContact.fr_Id__c, relatedContact);
                                           if(relatedContact.OpportunityContactRoles.size() > 0) {
@@ -244,12 +244,12 @@ public class frDonation extends frModel implements frSyncable {
         Contact supporter = contactsByFunraiseId.get(funraiseSupporterId);
         OpportunityContactRole newRole = new OpportunityContactRole();
         newRole.ContactId = supporter.Id;
-        newRole.OpportunityId = getOpportunityId();
+        newRole.OpportunityId = getSalesforceId();
         newRole.Role = role;
         return newRole;
     }
     
-    public String getOpportunityId() {
+    protected override String getSalesforceId(){
         return this.o != null ? this.o.Id : null;
     }
     
@@ -289,6 +289,13 @@ public class frDonation extends frModel implements frSyncable {
     
     protected override frUtil.Entity getFrType() {
         return frUtil.Entity.DONATION;
+    }
+    
+    protected override Datetime getUpdtime() {
+        if(getRequestBody().containsKey('donation_updtime')) {
+            return Datetime.newInstance((Long)getRequestBody().get('donation_updtime'));
+        }
+        return null;
     }
     
     ///CONSTANTS///

--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -291,13 +291,10 @@ public class frDonation extends frModel implements frSyncable {
         return frUtil.Entity.DONATION;
     }
     
-    protected override Datetime getUpdtime() {
-        if(getRequestBody().containsKey('donation_updtime')) {
-            return Datetime.newInstance((Long)getRequestBody().get('donation_updtime'));
-        }
-        return null;
+    protected override String getUpdtimeJsonKey() {
+        return 'donation_updtime';
     }
-    
+
     ///CONSTANTS///
 
     public static final String TYPE = 'Donation';

--- a/src/classes/frDonor.cls
+++ b/src/classes/frDonor.cls
@@ -44,7 +44,7 @@ public class frDonor extends frModel implements frSyncable{
     public static List<frMapping__c> mappings {
         get {
             if(mappings == null) {
-                mappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Type__c FROM frMapping__c WHERE Type__c = :TYPE ORDER BY CreatedDate];
+                mappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :TYPE ORDER BY CreatedDate];
             }
             return mappings;
         }
@@ -55,7 +55,7 @@ public class frDonor extends frModel implements frSyncable{
         return mappings;
     }
     
-    private Contact c;
+    private Contact supporterContact;
     
     public frDonor(Sync_Attempt__c syncRecord){
         super(syncRecord);
@@ -64,7 +64,7 @@ public class frDonor extends frModel implements frSyncable{
     public Boolean sync() {
         Boolean result = false;
         Map<String, Object> request = getRequestBody();
-        Contact supporterContact = null;
+        supporterContact = null;
         String frId = getFunraiseId();
         //try to find a donor that's already been integrated, use their funraise ID
         List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where fr_ID__c = :frId FOR UPDATE');
@@ -158,6 +158,11 @@ public class frDonor extends frModel implements frSyncable{
             return donor;
         }
         return null;
+    }
+    
+    protected override String getSalesforceId() {
+        return supporterContact != null ? supporterContact.Id : null;
+        
     }
 
     protected override Set<Schema.SObjectField> getFields() {

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -105,7 +105,7 @@ public class frDonorTest {
         request.put('id', existingSupporter.fr_Id__c);
         request.put('lastName', null);
         request.put('institutionName', 'Test Inst Name');
-
+        
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonorController.syncEntity();
@@ -138,7 +138,7 @@ public class frDonorTest {
         Test.stopTest();
         
         String frId = String.valueOf(getTestRequest().get('id'));
-		Contact syncedContact = [SELECT Id, fr_ID__c, Email FROM Contact WHERE fr_Id__c = :frId];
+        Contact syncedContact = [SELECT Id, fr_ID__c, Email FROM Contact WHERE fr_Id__c = :frId];
         System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
         Integer countAfterSync = [SELECT COUNT() FROM Contact];
         System.assertEquals(countBeforeSync, countAfterSync, 'No additional contacts should have been created');
@@ -159,7 +159,7 @@ public class frDonorTest {
         insert new List<Contact>{existing, noMatch};
             
         Integer countBeforeSync = [SELECT COUNT() FROM Contact];
-
+        
         frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
         frWSDonorController.syncEntity();        
@@ -253,7 +253,7 @@ public class frDonorTest {
         Map<String, Object> request = getTestRequest();
         request.put('id', existing.fr_Id__c);
         request.put('email', 'example.email.overwrite@example.com');
-
+        
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonorController.syncEntity();        
@@ -282,7 +282,7 @@ public class frDonorTest {
         request.put('id', existing.fr_Id__c);
         request.put('email', newEmail); //should overwrite existing value
         request.put('country', null);  //should not overwrite existing value
-
+        
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonorController.syncEntity();        
@@ -312,7 +312,7 @@ public class frDonorTest {
         request.put('id', existing.fr_Id__c);
         request.put('email', newEmail); //should overwrite existing value
         request.put('updtime', DateTime.now().addDays(1).getTime()); //one day in the future, so it should always be more recent
-
+        
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonorController.syncEntity();        
@@ -341,7 +341,7 @@ public class frDonorTest {
         request.put('id', existing.fr_Id__c);
         request.put('email', newEmail); //should overwrite existing value
         request.put('updtime', DateTime.now().addDays(-50).getTime()); //in the past, so it should not be more recent than Salesforce
-
+        
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonorController.syncEntity();        
@@ -361,7 +361,7 @@ public class frDonorTest {
         insert new frMapping__c(Type__c = frDonor.TYPE, Name = frField+sfField, 
                                 fr_Name__c = frField, sf_Name__c = sfField, Conflict_Resolution__c = conflictResolution);
     }
-
+    
     public static Contact getTestContact(Boolean save) {
         Contact contact = new Contact(
             FirstName = 'Bruce', LastName = 'Wayne', Email = 'bruce@wayne.example.com',

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -239,8 +239,127 @@ public class frDonorTest {
         System.assertEquals(1, newContacts, 'The funraise donor id was not populated to the contact field');
     }
     
+    static testMethod void syncEntity_conflictResolution_noOverwrite() {
+        createMapping('firstName', 'FirstName');
+        createMapping('lastName', 'LastName');
+        createMapping('email', 'email', frModel.MAPPING_NO_OVERWRITE);
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry');
+        
+        Contact existing = getTestContact(true);
+        Map<String, Object> request = getTestRequest();
+        request.put('id', existing.fr_Id__c);
+        request.put('email', 'example.email.overwrite@example.com');
+
+        frTestUtil.createTestPost(request);
+        Test.startTest();
+        frWSDonorController.syncEntity();        
+        Test.stopTest();
+        frTestUtil.assertNoErrors();
+        
+        Contact syncedContact = [SELECT Id, fr_ID__c, Email FROM Contact WHERE fr_Id__c = :existing.fr_Id__c];
+        System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
+        System.assertEquals(syncedContact.Email, existing.Email, 'The email should not have changed since the NO_OVERWRITE conflict resolution was used');
+    }
+    
+    static testMethod void syncEntity_conflictResolution_overwriteNonNull() {
+        createMapping('firstName', 'FirstName');
+        createMapping('lastName', 'LastName');
+        createMapping('email', 'email', frModel.MAPPING_OVERWRITE_NON_NULL);
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry', frModel.MAPPING_OVERWRITE_NON_NULL);
+        
+        String newEmail = 'example.email.overwrite@example.com';
+        
+        Contact existing = getTestContact(true);
+        Map<String, Object> request = getTestRequest();
+        request.put('id', existing.fr_Id__c);
+        request.put('email', newEmail); //should overwrite existing value
+        request.put('country', null);  //should not overwrite existing value
+
+        frTestUtil.createTestPost(request);
+        Test.startTest();
+        frWSDonorController.syncEntity();        
+        Test.stopTest();
+        frTestUtil.assertNoErrors();
+        
+        Contact syncedContact = [SELECT Id, fr_ID__c, Email, MailingCountry FROM Contact WHERE fr_Id__c = :existing.fr_Id__c];
+        System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
+        System.assertEquals(syncedContact.Email, newEmail, 'The email should have changed since the OVERWRITE_NON_NULL conflict resolution was used and the incoming value was non null');
+        System.assertEquals(syncedContact.MailingCountry, existing.MailingCountry, 'The country should NOT have changed since the OVERWRITE_NON_NULL conflict resolution was used and the incoming value was null');
+    }
+    
+    static testMethod void syncEntity_conflictResolution_overwriteMoreRecent_isMoreRecent() {
+        createMapping('firstName', 'FirstName');
+        createMapping('lastName', 'LastName');
+        createMapping('email', 'email', frModel.MAPPING_OVERWRITE_RECENT);
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry');
+        
+        String newEmail = 'example.email.overwrite@example.com';
+        
+        Contact existing = getTestContact(true);
+        Map<String, Object> request = getTestRequest();
+        request.put('id', existing.fr_Id__c);
+        request.put('email', newEmail); //should overwrite existing value
+        request.put('updtime', DateTime.now().addDays(1).getTime()); //one day in the future, so it should always be more recent
+
+        frTestUtil.createTestPost(request);
+        Test.startTest();
+        frWSDonorController.syncEntity();        
+        Test.stopTest();
+        frTestUtil.assertNoErrors();
+        
+        Contact syncedContact = [SELECT Id, fr_ID__c, Email, MailingCountry FROM Contact WHERE fr_Id__c = :existing.fr_Id__c];
+        System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
+        System.assertEquals(syncedContact.Email, newEmail, 'The email should have changed since the OVERWRITE_RECENT conflict resolution was used and the updtime was more recent than Salesforce');
+    }
+    
+    static testMethod void syncEntity_conflictResolution_overwriteMoreRecent_isNotMoreRecent() {
+        createMapping('firstName', 'FirstName');
+        createMapping('lastName', 'LastName');
+        createMapping('email', 'email', frModel.MAPPING_OVERWRITE_RECENT);
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry');
+        
+        String newEmail = 'example.email.overwrite@example.com';
+        
+        Contact existing = getTestContact(true);
+        Map<String, Object> request = getTestRequest();
+        request.put('id', existing.fr_Id__c);
+        request.put('email', newEmail); //should overwrite existing value
+        request.put('updtime', DateTime.now().addDays(-50).getTime()); //in the past, so it should not be more recent than Salesforce
+
+        frTestUtil.createTestPost(request);
+        Test.startTest();
+        frWSDonorController.syncEntity();        
+        Test.stopTest();
+        frTestUtil.assertNoErrors();
+        
+        Contact syncedContact = [SELECT Id, fr_ID__c, Email, MailingCountry FROM Contact WHERE fr_Id__c = :existing.fr_Id__c];
+        System.assertEquals(existing.Id, syncedContact.Id, 'The existing contact should have been used');
+        System.assertEquals(syncedContact.Email, existing.Email, 'The email should not have changed since the OVERWRITE_RECENT conflict resolution was used and the updtime was more recent than Salesforce');
+    }
+    
     private static void createMapping(String frField, String sfField) {
-        insert new frMapping__c(Name = frField+sfField, fr_Name__c = frField, sf_Name__c = sfField, Type__c = frDonor.TYPE);
+        createMapping(frField, sfField, null);
+    }
+    
+    private static void createMapping(String frField, String sfField, String conflictResolution) {
+        insert new frMapping__c(Type__c = frDonor.TYPE, Name = frField+sfField, 
+                                fr_Name__c = frField, sf_Name__c = sfField, Conflict_Resolution__c = conflictResolution);
     }
 
     public static Contact getTestContact(Boolean save) {
@@ -306,6 +425,7 @@ public class frDonorTest {
         request.put('fundraiser', false);
         request.put('donor_tags', 'FeedingPoor EatingFood');
         request.put('donor_cretime', 1487801043597L);
+        request.put('updtime', 1658702180337L);
         return request;
     }
 }

--- a/src/classes/frModel.cls
+++ b/src/classes/frModel.cls
@@ -32,9 +32,13 @@ public with sharing abstract class frModel {
         return false;
     }
     
-    protected virtual Datetime getUpdtime() {
-        if(getRequestBody().containsKey('updtime')) {
-            return Datetime.newInstance((Long)getRequestBody().get('updtime'));
+    protected virtual String getUpdtimeJsonKey() {
+        return 'updtime';
+    }
+    
+    private Datetime getUpdtime() {
+        if(getRequestBody().containsKey(getUpdtimeJsonKey())) {
+            return Datetime.newInstance((Long)getRequestBody().get(getUpdtimeJsonKey()));
         }
         return null;
     }
@@ -72,7 +76,7 @@ public with sharing abstract class frModel {
     }
     
     protected void applyMappings(SObject record, Map<String, Object> request) {
-    	String sObjectName = record.getSObjectType().getDescribe().getName();
+        String sObjectName = record.getSObjectType().getDescribe().getName();
         Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(sObjectName);
         
         //a single funraise field might flow into multiple salesforce fields
@@ -105,7 +109,7 @@ public with sharing abstract class frModel {
             }
         }        
         if(needLastModifiedDate) {
-        	fieldsToQueryFor.add('LastModifiedDate');    
+            fieldsToQueryFor.add('LastModifiedDate');    
         }
         
         String funraiseId = getFunraiseId();
@@ -138,7 +142,7 @@ public with sharing abstract class frModel {
                     Object incomingValue = request.get(fieldName);
                     Boolean write = false;
                     if(String.isBlank(mapping.Conflict_Resolution__c) || mapping.Conflict_Resolution__c == MAPPING_OVERWRITE) {
-                    	write = true;	    
+                        write = true;	    
                     } else if (mapping.Conflict_Resolution__c == MAPPING_OVERWRITE_NON_NULL && (incomingValue != null || (incomingValue instanceOf String && String.isNotBlank((String)incomingValue)))) {
                         write = true;
                     } else if (mapping.Conflict_Resolution__c == MAPPING_NO_OVERWRITE) {
@@ -146,9 +150,12 @@ public with sharing abstract class frModel {
                         write = existingValue == null;
                     } else if (mapping.Conflict_Resolution__c == MAPPING_OVERWRITE_RECENT && isMoreRecent) {
                         write = true;
+                    } else if (String.isNotBlank(mapping.Conflict_Resolution__c) && !VALID_CONFLICT_RESOLUTIONS.contains(mapping.Conflict_Resolution__c)) {
+                        insert new Error__c(Error__c = 'Field mapping exception. Unknown conflict resolution provided. Object type: '+ sObjectName +
+                                            ' - Field: '+field.getDescribe().getName() + 'Conflict Resolution: '+ mapping.Conflict_Resolution__c);
                     }
                     if(write) {
-                    	write(record, field, mapping.sf_Name__c, incomingValue, funraiseId);    
+                        write(record, field, mapping.sf_Name__c, incomingValue, funraiseId);    
                     }
                 }
             }
@@ -157,7 +164,7 @@ public with sharing abstract class frModel {
             Schema.SObjectField field = fields.get(constantMapping.sf_Name__c);
             write(record, field, constantMapping.sf_Name__c, constantMapping.Constant_Value__c, funraiseId);
         }
-
+        
         record.put('fr_ID__c', funraiseId);
     }
     
@@ -208,9 +215,9 @@ public with sharing abstract class frModel {
             record.put(field, value);
         } catch (Exception ex) {
             insert new Error__c(Error__c = 'Field mapping exception. Object type: '+ record.getSObjectType().getDescribe().getName()
-                +' Record Id: '+record.Id+' - Funraise Id: '+ funraiseId + ' - Field: '+field.getDescribe().getName()+' - Value: '+value
-                +' Exception: '+ex
-            );
+                                +' Record Id: '+record.Id+' - Funraise Id: '+ funraiseId + ' - Field: '+field.getDescribe().getName()+' - Value: '+value
+                                +' Exception: '+ex
+                               );
         }
     }
     
@@ -238,9 +245,13 @@ public with sharing abstract class frModel {
             deleteLogs();
         }
     }
-
+    
     @future
     private static void deleteLogs() {
         delete [SELECT Id FROM Error__c ORDER BY CreatedDate DESC LIMIT 10000 OFFSET 100];
     }
+    
+    private static final Set<String> VALID_CONFLICT_RESOLUTIONS = new Set<String>{
+        MAPPING_OVERWRITE, MAPPING_NO_OVERWRITE, MAPPING_OVERWRITE_NON_NULL, MAPPING_OVERWRITE_RECENT
+    };
 }

--- a/src/classes/frModel.cls
+++ b/src/classes/frModel.cls
@@ -1,4 +1,9 @@
 public with sharing abstract class frModel {
+    public static final String MAPPING_OVERWRITE = 'overwrite';
+    public static final String MAPPING_NO_OVERWRITE = 'do_not_overwrite';
+    public static final String MAPPING_OVERWRITE_NON_NULL = 'overwrite_non_null';
+    public static final String MAPPING_OVERWRITE_RECENT = 'overwrite_more_recent';
+    
     protected Sync_Attempt__c syncRecord;
     protected Map<String, Object> requestBody;
     protected Boolean createLogRecord = false;
@@ -19,8 +24,19 @@ public with sharing abstract class frModel {
         return String.valueOf(getRequestBody().get('id'));
     }
     
+    protected virtual String getSalesforceId() {
+        return null;
+    }
+    
     protected virtual Boolean requireObjectDeletePermission() {
         return false;
+    }
+    
+    protected virtual Datetime getUpdtime() {
+        if(getRequestBody().containsKey('updtime')) {
+            return Datetime.newInstance((Long)getRequestBody().get('updtime'));
+        }
+        return null;
     }
     
     protected abstract Set<Schema.SObjectField> getFields();
@@ -56,32 +72,84 @@ public with sharing abstract class frModel {
     }
     
     protected void applyMappings(SObject record, Map<String, Object> request) {
-    	Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(record.getSObjectType().getDescribe().getName());
-        String funraiseId = String.valueOf(request.get('id'));
+    	String sObjectName = record.getSObjectType().getDescribe().getName();
+        Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(sObjectName);
         
         //a single funraise field might flow into multiple salesforce fields
-        Map<String, List<frMapping__c>> frNameToSfName = new Map<String, List<frMapping__c>>();
+        Map<String, List<frMapping__c>> frFieldToMappings = new Map<String, List<frMapping__c>>();
         List<frMapping__c> constantMappings = new List<frMapping__c>();
+        Set<String> fieldsToQueryFor = new Set<String>();
+        Boolean needLastModifiedDate = false;
+        
         for(frMapping__c mapping : getMappings()) {
             if(mapping.Is_Constant__c) {
                 constantMappings.add(mapping);
             } else {
                 List<frMapping__c> mappings;
-                if(frNameToSfName.containsKey(mapping.fr_Name__c)) {
-                    mappings = frNameToSfName.get(mapping.fr_Name__c);
+                if(frFieldToMappings.containsKey(mapping.fr_Name__c)) {
+                    mappings = frFieldToMappings.get(mapping.fr_Name__c);
                 } else {
                     mappings = new List<frMapping__c>();
                 }
                 mappings.add(mapping);
-                frNameToSfName.put(mapping.fr_Name__c, mappings);
+                frFieldToMappings.put(mapping.fr_Name__c, mappings);
             }
+            
+            if(mapping.Conflict_Resolution__c == MAPPING_NO_OVERWRITE) {
+                //We need to know the existing values of these fields
+                //if null, we can sync the incoming data.  Otherwise, we don't overwrite
+                fieldsToQueryFor.add(mapping.sf_Name__c);
+            }
+            if(!needLastModifiedDate && mapping.Conflict_Resolution__c == MAPPING_OVERWRITE_RECENT) {
+                needLastModifiedDate = true;
+            }
+        }        
+        if(needLastModifiedDate) {
+        	fieldsToQueryFor.add('LastModifiedDate');    
         }
-
-        for(String fieldName : frNameToSfName.keySet()) {
+        
+        String funraiseId = getFunraiseId();
+        String salesforceId = getSalesforceId();
+        SObject queriedFieldsRecord = null;
+        if(!fieldsToQueryFor.isEmpty()) {
+            String query = 'SELECT ' + String.join(new List<String>(fieldsToQueryFor), ',') 
+                + ' FROM ' + sObjectName + ' WHERE ';
+            if(getSalesforceId() != null) {
+                query += 'Id = :salesforceId';
+            } else {
+                query += 'funraise__fr_Id__c = :funraiseId';
+            }
+            List<SObject> results = Database.query(query);
+            if(results.size() > 0) {
+                queriedFieldsRecord = results.get(0);
+            }    
+        }
+        
+        Boolean isMoreRecent = false;
+        if(needLastModifiedDate && queriedFieldsRecord != null) {
+            Datetime sfRecordUpdtime = (Datetime)queriedFieldsRecord.get('LastModifiedDate');
+            isMoreRecent = getUpdtime() != null ? getUpdtime() > sfRecordUpdtime : false;
+        }
+        
+        for(String fieldName : frFieldToMappings.keySet()) {
             if(request.containsKey(fieldName)) {
-                for(frMapping__c mapping : frNameToSfName.get(fieldName)) {
+                for(frMapping__c mapping : frFieldToMappings.get(fieldName)) {
                     Schema.SObjectField field = fields.get(mapping.sf_Name__c);
-                    write(record, field, mapping.sf_Name__c, request.get(fieldName), funraiseId);                    
+                    Object incomingValue = request.get(fieldName);
+                    Boolean write = false;
+                    if(String.isBlank(mapping.Conflict_Resolution__c) || mapping.Conflict_Resolution__c == MAPPING_OVERWRITE) {
+                    	write = true;	    
+                    } else if (mapping.Conflict_Resolution__c == MAPPING_OVERWRITE_NON_NULL && (incomingValue != null || (incomingValue instanceOf String && String.isNotBlank((String)incomingValue)))) {
+                        write = true;
+                    } else if (mapping.Conflict_Resolution__c == MAPPING_NO_OVERWRITE) {
+                        Object existingValue = queriedFieldsRecord != null ? queriedFieldsRecord.get(field) : null;
+                        write = existingValue == null;
+                    } else if (mapping.Conflict_Resolution__c == MAPPING_OVERWRITE_RECENT && isMoreRecent) {
+                        write = true;
+                    }
+                    if(write) {
+                    	write(record, field, mapping.sf_Name__c, incomingValue, funraiseId);    
+                    }
                 }
             }
         }

--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -38,28 +38,28 @@ public with sharing class frSetupController {
     }
     
     public static String MAPPING_OVERWRITE {
-    	get {
-			return frModel.MAPPING_OVERWRITE;
-		}
-		private set;
+        get {
+            return frModel.MAPPING_OVERWRITE;
+        }
+        private set;
     }
     public static String MAPPING_NO_OVERWRITE {
         get {
-			return frModel.MAPPING_NO_OVERWRITE;
-		}
-		private set;
+            return frModel.MAPPING_NO_OVERWRITE;
+        }
+        private set;
     }
     public static String MAPPING_OVERWRITE_NON_NULL {
         get {
-			return frModel.MAPPING_OVERWRITE_NON_NULL;
-		}
-		private set;
+            return frModel.MAPPING_OVERWRITE_NON_NULL;
+        }
+        private set;
     }
     public static String MAPPING_OVERWRITE_RECENT  {
         get {
-			return frModel.MAPPING_OVERWRITE_RECENT;
-		}
-		private set;
+            return frModel.MAPPING_OVERWRITE_RECENT;
+        }
+        private set;
     }
 
 	public List<SelectOption> donationSFOptions {get; set;}

--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -36,6 +36,31 @@ public with sharing class frSetupController {
         }
         private set;
     }
+    
+    public static String MAPPING_OVERWRITE {
+    	get {
+			return frModel.MAPPING_OVERWRITE;
+		}
+		private set;
+    }
+    public static String MAPPING_NO_OVERWRITE {
+        get {
+			return frModel.MAPPING_NO_OVERWRITE;
+		}
+		private set;
+    }
+    public static String MAPPING_OVERWRITE_NON_NULL {
+        get {
+			return frModel.MAPPING_OVERWRITE_NON_NULL;
+		}
+		private set;
+    }
+    public static String MAPPING_OVERWRITE_RECENT  {
+        get {
+			return frModel.MAPPING_OVERWRITE_RECENT;
+		}
+		private set;
+    }
 
 	public List<SelectOption> donationSFOptions {get; set;}
 	public List<SelectOption> donationFROptions {get; set;}

--- a/src/objects/Answer__c.object
+++ b/src/objects/Answer__c.object
@@ -78,6 +78,7 @@
     </fields>
     <fields>
         <fullName>Question_Text__c</fullName>
+        <deprecated>false</deprecated>
         <description>Displays the text of the question that was presented to the supporter</description>
         <externalId>false</externalId>
         <formula>Question__r.Description__c</formula>

--- a/src/objects/frMapping__c.object
+++ b/src/objects/frMapping__c.object
@@ -5,6 +5,7 @@
     <fields>
         <fullName>Conflict_Resolution__c</fullName>
         <defaultValue>&quot;overwrite&quot;</defaultValue>
+        <deprecated>false</deprecated>
         <description>How should existing data be reconciled with incoming data from Funraise</description>
         <externalId>false</externalId>
         <inlineHelpText>How should existing data be reconciled with incoming data from Funraise</inlineHelpText>

--- a/src/objects/frMapping__c.object
+++ b/src/objects/frMapping__c.object
@@ -3,6 +3,19 @@
     <customSettingsType>List</customSettingsType>
     <enableFeeds>false</enableFeeds>
     <fields>
+        <fullName>Conflict_Resolution__c</fullName>
+        <defaultValue>&quot;overwrite&quot;</defaultValue>
+        <description>How should existing data be reconciled with incoming data from Funraise</description>
+        <externalId>false</externalId>
+        <inlineHelpText>How should existing data be reconciled with incoming data from Funraise</inlineHelpText>
+        <label>Conflict Resolution</label>
+        <length>100</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Constant_Value__c</fullName>
         <deprecated>false</deprecated>
         <externalId>false</externalId>

--- a/src/pages/frSetup.page
+++ b/src/pages/frSetup.page
@@ -50,6 +50,17 @@
 				</apex:column>
 				<apex:column >
 					<apex:facet name="header">
+                        Conflict Resolution
+                    </apex:facet>
+					<apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+						<apex:selectOption itemValue="{!MAPPING_OVERWRITE}" itemLabel="Overwrite Existing Data with Funraise Data" />
+                        <apex:selectOption itemValue="{!MAPPING_NO_OVERWRITE}" itemLabel="Do Not Overwrite Existing Data" />
+                        <apex:selectOption itemValue="{!MAPPING_OVERWRITE_NON_NULL}" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
+                        <apex:selectOption itemValue="{!MAPPING_OVERWRITE_RECENT}" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
+					</apex:selectList> 
+				</apex:column>
+				<apex:column >
+					<apex:facet name="header">
 						Remove
 					</apex:facet>
 					<apex:commandLink action="{!removeMapping}" value="Remove" rendered="{!mapping.id != null}">
@@ -92,6 +103,17 @@
 					</apex:facet>
 					<apex:selectList value="{!mapping.sf_Name__c}" size="1">
 						<apex:selectOptions value="{!donorSFOptions}" />
+					</apex:selectList> 
+				</apex:column>
+				<apex:column >
+					<apex:facet name="header">
+                        Conflict Resolution
+                    </apex:facet>
+					<apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+						<apex:selectOption itemValue="overwrite" itemLabel="Overwrite Existing Data with Funraise Data" />
+                        <apex:selectOption itemValue="do_not_overwrite" itemLabel="Do Not Overwrite Existing Data" />
+                        <apex:selectOption itemValue="overwrite_non_null" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
+                        <apex:selectOption itemValue="overwrite_more_recent" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
 					</apex:selectList> 
 				</apex:column>
 				<apex:column >

--- a/src/pages/frSetup.page
+++ b/src/pages/frSetup.page
@@ -1,135 +1,135 @@
 <apex:page showHeader="true" sidebar="false" controller="frSetupController">
-	<apex:pageMessages />
-	<apex:form >
-	<apex:pageBlock title="Instructions">
-		<apex:pageBlockButtons location="top">
-			<apex:commandButton action="{!save}" value="Save Mappings" />
-			<apex:commandButton action="{!cancel}" value="Discard Changes" />
-			<apex:commandButton action="{!defaults}" value="Use Default Mappings" onclick="return confirm('This will delete ALL of your current mappings and replace them with the defaults.  Are you sure you want to continue?');" />
-		</apex:pageBlockButtons>
-		<h2>
-		Use this page to define what fields should be populated when a new donation (opportunity) or donor (contact) is sent from the 
-		Funraise platform
-		</h2>
-		<br/> <br/>
-		<h2>
-		If you would prefer to hardcode a value for an opportunity or contact, check the "Constant?" box and enter the hardcoded value.  
-		If not, you can select a field value that comes from Funraise
-		</h2>
-	</apex:pageBlock>
-	<apex:pageBlock title="Donation --> Opportunity">
-		<apex:pageBlockButtons location="top">
-			<apex:commandButton action="{!donationDefaults}" value="Use Default Mappings" onclick="return confirm('This will delete your current mappings for donation and replace them with the defaults.  Are you sure you want to continue?');" />
-		</apex:pageBlockButtons>
-		<apex:pageBlockSection columns="1">
-			<apex:pageBlockTable value="{!donationMappings}" var="mapping" id="donationTable" >
-				<apex:column >
-					<apex:facet name="header">
-						Constant?
-					</apex:facet>
-					<apex:inputField value="{!mapping.Is_Constant__c}" >
-						<apex:actionSupport event="onchange" reRender="fr-field-column" />
-					</apex:inputField>
-				</apex:column>
-				<apex:column id="fr-field-column">
-					<apex:facet name="header">
-						Value
-					</apex:facet>
-					<apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
-					<apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
-						<apex:selectOptions value="{!donationFROptions}" />
-					</apex:selectList> 
-				</apex:column>
-				<apex:column >
-					<apex:facet name="header">
-						Opportunity Field
-					</apex:facet>
-					<apex:selectList value="{!mapping.sf_Name__c}" size="1">
-						<apex:selectOptions value="{!donationSFOptions}" />
-					</apex:selectList> 
-				</apex:column>
-				<apex:column >
-					<apex:facet name="header">
-                        Conflict Resolution
-                    </apex:facet>
-					<apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
-						<apex:selectOption itemValue="{!MAPPING_OVERWRITE}" itemLabel="Overwrite Existing Data with Funraise Data" />
-                        <apex:selectOption itemValue="{!MAPPING_NO_OVERWRITE}" itemLabel="Do Not Overwrite Existing Data" />
-                        <apex:selectOption itemValue="{!MAPPING_OVERWRITE_NON_NULL}" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
-                        <apex:selectOption itemValue="{!MAPPING_OVERWRITE_RECENT}" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
-					</apex:selectList> 
-				</apex:column>
-				<apex:column >
-					<apex:facet name="header">
-						Remove
-					</apex:facet>
-					<apex:commandLink action="{!removeMapping}" value="Remove" rendered="{!mapping.id != null}">
-						<apex:param name="id" value="{!mapping.Id}" />
-						<apex:param name="type" value="{!DONATION_TYPE}" />
-					</apex:commandLink>
-				</apex:column>
-			</apex:pageBlockTable>
-			<apex:commandLink action="{!addMapping}" value="Add Donation Mapping" reRender="donationTable">
-				<apex:param name="type" value="{!DONATION_TYPE}" />
-			</apex:commandLink>
-		</apex:pageBlockSection>
-	</apex:pageBlock>
-	<apex:pageBlock title="Donor --> Contact">
-		<apex:pageBlockButtons location="top">
-			<apex:commandButton action="{!donorDefaults}" value="Use Default Mappings" onclick="return confirm('This will delete your current mappings for donor and replace them with the defaults.  Are you sure you want to continue?');" />
-		</apex:pageBlockButtons>
-		<apex:pageBlockSection columns="1">
-			<apex:pageBlockTable value="{!donorMappings}" var="mapping" id="donorTable">
-				<apex:column >
-					<apex:facet name="header">
-						Constant?
-					</apex:facet>
-					<apex:inputField value="{!mapping.Is_Constant__c}" >
-						<apex:actionSupport event="onchange" reRender="fr-field-column" />
-					</apex:inputField>
-				</apex:column>
-				<apex:column id="fr-field-column">
-					<apex:facet name="header">
-						Value
-					</apex:facet>
-					<apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
-					<apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
-						<apex:selectOptions value="{!donorFROptions}" />
-					</apex:selectList> 
-				</apex:column>
-				<apex:column >
-					<apex:facet name="header">
-						Contact Field
-					</apex:facet>
-					<apex:selectList value="{!mapping.sf_Name__c}" size="1">
-						<apex:selectOptions value="{!donorSFOptions}" />
-					</apex:selectList> 
-				</apex:column>
-				<apex:column >
-					<apex:facet name="header">
-                        Conflict Resolution
-                    </apex:facet>
-					<apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
-						<apex:selectOption itemValue="overwrite" itemLabel="Overwrite Existing Data with Funraise Data" />
-                        <apex:selectOption itemValue="do_not_overwrite" itemLabel="Do Not Overwrite Existing Data" />
-                        <apex:selectOption itemValue="overwrite_non_null" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
-                        <apex:selectOption itemValue="overwrite_more_recent" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
-					</apex:selectList> 
-				</apex:column>
-				<apex:column >
-					<apex:facet name="header">
-						Remove
-					</apex:facet>
-					<apex:commandLink action="{!removeMapping}" value="Remove" rendered="{!mapping.id != null}">
-						<apex:param name="id" value="{!mapping.Id}" />
-						<apex:param name="type" value="{!DONOR_TYPE}" />
-					</apex:commandLink>
-				</apex:column>
-			</apex:pageBlockTable>
-			<apex:commandLink action="{!addMapping}" value="Add Donor Mapping" reRender="donorTable">
-				<apex:param name="type" value="{!DONOR_TYPE}" />
-			</apex:commandLink>
-		</apex:pageBlockSection>
-	</apex:pageBlock>
-	</apex:form>
+    <apex:pageMessages />
+    <apex:form >
+        <apex:pageBlock title="Instructions">
+            <apex:pageBlockButtons location="top">
+                <apex:commandButton action="{!save}" value="Save Mappings" />
+                <apex:commandButton action="{!cancel}" value="Discard Changes" />
+                <apex:commandButton action="{!defaults}" value="Use Default Mappings" onclick="return confirm('This will delete ALL of your current mappings and replace them with the defaults.  Are you sure you want to continue?');" />
+            </apex:pageBlockButtons>
+            <h2>
+                Use this page to define what fields should be populated when a new donation (opportunity) or donor (contact) is sent from the 
+                Funraise platform
+            </h2>
+            <br/> <br/>
+            <h2>
+                If you would prefer to hardcode a value for an opportunity or contact, check the "Constant?" box and enter the hardcoded value.  
+                If not, you can select a field value that comes from Funraise
+            </h2>
+        </apex:pageBlock>
+        <apex:pageBlock title="Donation --> Opportunity">
+            <apex:pageBlockButtons location="top">
+                <apex:commandButton action="{!donationDefaults}" value="Use Default Mappings" onclick="return confirm('This will delete your current mappings for donation and replace them with the defaults.  Are you sure you want to continue?');" />
+            </apex:pageBlockButtons>
+            <apex:pageBlockSection columns="1">
+                <apex:pageBlockTable value="{!donationMappings}" var="mapping" id="donationTable" >
+                    <apex:column >
+                        <apex:facet name="header">
+                            Constant?
+                        </apex:facet>
+                        <apex:inputField value="{!mapping.Is_Constant__c}" >
+                            <apex:actionSupport event="onchange" reRender="fr-field-column" />
+                        </apex:inputField>
+                    </apex:column>
+                    <apex:column id="fr-field-column">
+                        <apex:facet name="header">
+                            Value
+                        </apex:facet>
+                        <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
+                        <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
+                            <apex:selectOptions value="{!donationFROptions}" />
+                        </apex:selectList> 
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Opportunity Field
+                        </apex:facet>
+                        <apex:selectList value="{!mapping.sf_Name__c}" size="1">
+                            <apex:selectOptions value="{!donationSFOptions}" />
+                        </apex:selectList> 
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Conflict Resolution
+                        </apex:facet>
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+                            <apex:selectOption itemValue="{!MAPPING_OVERWRITE}" itemLabel="Overwrite Existing Data with Funraise Data" />
+                            <apex:selectOption itemValue="{!MAPPING_NO_OVERWRITE}" itemLabel="Do Not Overwrite Existing Data" />
+                            <apex:selectOption itemValue="{!MAPPING_OVERWRITE_NON_NULL}" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
+                            <apex:selectOption itemValue="{!MAPPING_OVERWRITE_RECENT}" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
+                        </apex:selectList> 
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Remove
+                        </apex:facet>
+                        <apex:commandLink action="{!removeMapping}" value="Remove" rendered="{!mapping.id != null}">
+                            <apex:param name="id" value="{!mapping.Id}" />
+                            <apex:param name="type" value="{!DONATION_TYPE}" />
+                        </apex:commandLink>
+                    </apex:column>
+                </apex:pageBlockTable>
+                <apex:commandLink action="{!addMapping}" value="Add Donation Mapping" reRender="donationTable">
+                    <apex:param name="type" value="{!DONATION_TYPE}" />
+                </apex:commandLink>
+            </apex:pageBlockSection>
+        </apex:pageBlock>
+        <apex:pageBlock title="Donor --> Contact">
+            <apex:pageBlockButtons location="top">
+                <apex:commandButton action="{!donorDefaults}" value="Use Default Mappings" onclick="return confirm('This will delete your current mappings for donor and replace them with the defaults.  Are you sure you want to continue?');" />
+            </apex:pageBlockButtons>
+            <apex:pageBlockSection columns="1">
+                <apex:pageBlockTable value="{!donorMappings}" var="mapping" id="donorTable">
+                    <apex:column >
+                        <apex:facet name="header">
+                            Constant?
+                        </apex:facet>
+                        <apex:inputField value="{!mapping.Is_Constant__c}" >
+                            <apex:actionSupport event="onchange" reRender="fr-field-column" />
+                        </apex:inputField>
+                    </apex:column>
+                    <apex:column id="fr-field-column">
+                        <apex:facet name="header">
+                            Value
+                        </apex:facet>
+                        <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
+                        <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
+                            <apex:selectOptions value="{!donorFROptions}" />
+                        </apex:selectList> 
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Contact Field
+                        </apex:facet>
+                        <apex:selectList value="{!mapping.sf_Name__c}" size="1">
+                            <apex:selectOptions value="{!donorSFOptions}" />
+                        </apex:selectList> 
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Conflict Resolution
+                        </apex:facet>
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+                            <apex:selectOption itemValue="overwrite" itemLabel="Overwrite Existing Data with Funraise Data" />
+                            <apex:selectOption itemValue="do_not_overwrite" itemLabel="Do Not Overwrite Existing Data" />
+                            <apex:selectOption itemValue="overwrite_non_null" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
+                            <apex:selectOption itemValue="overwrite_more_recent" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
+                        </apex:selectList> 
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Remove
+                        </apex:facet>
+                        <apex:commandLink action="{!removeMapping}" value="Remove" rendered="{!mapping.id != null}">
+                            <apex:param name="id" value="{!mapping.Id}" />
+                            <apex:param name="type" value="{!DONOR_TYPE}" />
+                        </apex:commandLink>
+                    </apex:column>
+                </apex:pageBlockTable>
+                <apex:commandLink action="{!addMapping}" value="Add Donor Mapping" reRender="donorTable">
+                    <apex:param name="type" value="{!DONOR_TYPE}" />
+                </apex:commandLink>
+            </apex:pageBlockSection>
+        </apex:pageBlock>
+    </apex:form>
 </apex:page>


### PR DESCRIPTION
This will let users preserve existing data if they choose, or overwrite if the data from Funraise is more recent or not empty.
Resolving FUN-12869