### PR TITLE
Fixing an issue where using the "more recent" data reconciliation didn't work

### DIFF
--- a/src/classes/frDonor.cls
+++ b/src/classes/frDonor.cls
@@ -67,7 +67,7 @@ public class frDonor extends frModel implements frSyncable{
         supporterContact = null;
         String frId = getFunraiseId();
         //try to find a donor that's already been integrated, use their funraise ID
-        List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where fr_ID__c = :frId FOR UPDATE');
+        List<Contact> contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where fr_ID__c = :frId');
         if(contacts != null && contacts.size() > 0) {
             supporterContact = contacts.get(0);
         }
@@ -82,14 +82,14 @@ public class frDonor extends frModel implements frSyncable{
                     contacts = (List<Contact>)Database.query(
                         'select Id, fr_ID__c, LastName from Contact where '+
                         'Email = :email AND FirstName = :firstName AND LastName = :lastName '+
-                        'limit 1 FOR UPDATE'
+                        'limit 1'
                     );
                     supporterContact = applyMatch(contacts, frId);
                 }
                 
                 //if name wasn't present or no match was found, try on email only
                 if(supporterContact == null) {
-                    contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where Email = :email limit 1 FOR UPDATE');
+                    contacts = (List<Contact>)Database.query('select Id, fr_ID__c, LastName from Contact where Email = :email limit 1');
                     supporterContact = applyMatch(contacts, frId);                 
                 }
                 
@@ -118,7 +118,7 @@ public class frDonor extends frModel implements frSyncable{
                 if(String.isNotBlank(postalCode)) {
                     byAddress += ' and MailingPostalCode = :postalCode';
                 }
-                byAddress += ' limit 1 FOR UPDATE';
+                byAddress += ' limit 1';
                 
                 contacts = (List<Contact>)Database.query(byAddress);
                 supporterContact = applyMatch(contacts, frId);

--- a/src/classes/frDonorTest.cls
+++ b/src/classes/frDonorTest.cls
@@ -353,6 +353,30 @@ public class frDonorTest {
         System.assertEquals(syncedContact.Email, existing.Email, 'The email should not have changed since the OVERWRITE_RECENT conflict resolution was used and the updtime was more recent than Salesforce');
     }
     
+    static testMethod void syncEntity_conflictResolution_overwriteMoreRecent_noExistingRecord() {
+        createMapping('firstName', 'FirstName', frModel.MAPPING_OVERWRITE_RECENT);
+        createMapping('lastName', 'LastName', frModel.MAPPING_OVERWRITE_RECENT);
+        createMapping('email', 'email', frModel.MAPPING_OVERWRITE_RECENT);
+        createMapping('address1', 'MailingStreet');
+        createMapping('city', 'MailingCity');
+        createMapping('state', 'MailingState');
+        createMapping('postalCode', 'MailingPostalCode');
+        createMapping('country', 'MailingCountry');
+        
+        Map<String, Object> request = getTestRequest();       
+        frTestUtil.createTestPost(request);
+        Test.startTest();
+        frWSDonorController.syncEntity();        
+        Test.stopTest();
+        frTestUtil.assertNoErrors();
+        
+        String frId = String.valueOf(getTestRequest().get('id'));
+        Contact syncedContact = [SELECT Email, FirstName, LastName, fr_ID__c FROM Contact WHERE fr_Id__c = :frId];
+        System.assertEquals(syncedContact.Email, String.valueOf(getTestRequest().get('email')), 'The email from the request should be present on the newly created contact');
+        System.assertEquals(syncedContact.FirstName, String.valueOf(getTestRequest().get('firstName')), 'The firstName from the request should be present on the newly created contact');
+        System.assertEquals(syncedContact.LastName, String.valueOf(getTestRequest().get('lastName')), 'The lastName from the request should be present on the newly created contact');
+    }
+    
     private static void createMapping(String frField, String sfField) {
         createMapping(frField, sfField, null);
     }

--- a/src/classes/frModel.cls
+++ b/src/classes/frModel.cls
@@ -129,7 +129,7 @@ public with sharing abstract class frModel {
             }    
         }
         
-        Boolean isMoreRecent = false;
+        Boolean isMoreRecent = queriedFieldsRecord == null; //if we didn't get a queriedFieldsRecord returned, all fields from Funraise are more recent
         if(needLastModifiedDate && queriedFieldsRecord != null) {
             Datetime sfRecordUpdtime = (Datetime)queriedFieldsRecord.get('LastModifiedDate');
             isMoreRecent = getUpdtime() != null ? getUpdtime() > sfRecordUpdtime : false;

--- a/src/classes/frPledge.cls
+++ b/src/classes/frPledge.cls
@@ -37,7 +37,7 @@
 * CREATED: 2020 Funraise Inc - https://funraise.io
 * AUTHOR: Alex Molina
 */
-public class frPledge {
+public with sharing class frPledge {
     public static Pledge__c findActive(Id contactId, Date closeDate) {
         List<Pledge__c> possiblePledges = [SELECT Id FROM Pledge__c 
                                          WHERE Supporter__c = :contactId 

--- a/src/classes/frSyncRequestHandler.cls
+++ b/src/classes/frSyncRequestHandler.cls
@@ -1,6 +1,6 @@
 public with sharing class frSyncRequestHandler implements Database.Batchable<SObject> {
     public static final Integer MAX_ATTEMPTS = 3;
-    public static final Integer BATCH_SIZE = 50;
+    public static final Integer BATCH_SIZE = 20;
     public Database.QueryLocator start(Database.BatchableContext bc) {
         Id jobId = bc.getJobId();
 		Id classId = [SELECT ApexClassId FROM AsyncApexJob WHERE id = :jobId][0].ApexClassId;

--- a/src/classes/frSyncRequestHandlerTest.cls
+++ b/src/classes/frSyncRequestHandlerTest.cls
@@ -101,7 +101,7 @@ public class frSyncRequestHandlerTest {
         
         Test.startTest();
         frSyncRequestHandler handler = new frSyncRequestHandler();
-        Database.executeBatch(handler);
+        Database.executeBatch(handler, frSyncRequestHandler.BATCH_SIZE);
         Test.stopTest();
         
         for(Sync_Attempt__c attempt : [SELECT Id, Attempts__c FROM Sync_Attempt__c]) {


### PR DESCRIPTION
If an existing record didn't exist, we never thought the incoming data was more recent.  Fixed bug and added a test to confirm.

Resolving FUN-13224