### PR TITLE
[FUN-16693] Support NPC campaign members

### DIFF
--- a/src/classes/frCampaign.cls
+++ b/src/classes/frCampaign.cls
@@ -114,14 +114,18 @@ public class frCampaign extends frModel implements frSyncable {
         
         String supporterFunraiseId = String.valueOf(request.get('supporterId'));        
         if (String.isNotBlank(supporterFunraiseId)) {
-            List<Contact> contacts = [SELECT Id, AccountId, (SELECT Id FROM CampaignMembers WHERE CampaignId = :newCampaign.Id) 
-                                      FROM Contact WHERE fr_ID__c = :supporterFunraiseId];
-            if (contacts.size() > 0) {
-                Contact supporterContact = contacts.get(0);
-                if(supporterContact.CampaignMembers.size() == 0) {
+            Id supporterContactId = getCampaignMemberContactId(supporterFunraiseId);
+            if (supporterContactId != null) {
+                List<CampaignMember> campaignMembers = [
+                    SELECT Id
+                    FROM CampaignMember
+                    WHERE CampaignId = :newCampaign.Id
+                        AND ContactId = :supporterContactId
+                ];
+                if(campaignMembers.size() == 0) {
                     CampaignMember fundraiserMember = new CampaignMember(
                         CampaignId = newCampaign.Id,
-                        ContactId = supporterContact.Id
+                        ContactId = supporterContactId
                     );
                     try {
                         insert fundraiserMember;
@@ -138,6 +142,29 @@ public class frCampaign extends frModel implements frSyncable {
         }
         return result;
     }
+
+    private Id getCampaignMemberContactId(String supporterFunraiseId) {
+        if (frUtil.hasNPCobjects()) {
+            List<SObject> supporters = Database.query(
+                'SELECT Id, PersonContactId FROM Account WHERE fr_ID__c = :supporterFunraiseId'
+            );
+            if (supporters.size() > 0) {
+                Id personContactId = (Id)supporters.get(0).get('PersonContactId');
+                if (personContactId != null) {
+                    return personContactId;
+                }
+                if(createLogRecord) frUtil.logRelationshipError(getFrType(), getFunraiseId(),
+                    frUtil.Entity.PERSONACCOUNT, supporterFunraiseId, 'Person Account is missing PersonContactId');
+            }
+            return null;
+        }
+
+        List<Contact> contacts = [SELECT Id FROM Contact WHERE fr_ID__c = :supporterFunraiseId];
+        if (contacts.size() > 0) {
+            return contacts.get(0).Id;
+        }
+        return null;
+    }
     
     protected override Boolean requireObjectDeletePermission() {
         return true;
@@ -148,7 +175,7 @@ public class frCampaign extends frModel implements frSyncable {
     }
     
     protected override Set<Schema.SObjectField> getFields() {
-        return new Set<Schema.SObjectField> {
+        Set<Schema.SObjectField> fields = new Set<Schema.SObjectField> {
                 Campaign.Name,
                 Campaign.Description,
                 Campaign.Status,
@@ -158,13 +185,25 @@ public class frCampaign extends frModel implements frSyncable {
                 CampaignMember.CampaignId,
                 CampaignMember.ContactId
         };
+        if (frUtil.hasNPCobjects()) {
+            Map<String, Schema.SObjectField> accountFields = Account.SObjectType.getDescribe().fields.getMap();
+            fields.add(Account.fr_ID__c);
+            if (accountFields.containsKey('PersonContactId')) {
+                fields.add(accountFields.get('PersonContactId'));
+            }
+        }
+        return fields;
     }
     
     protected override Set<Schema.SObjectType> getObjects() {
-        return new Set<Schema.SObjectType> {
+        Set<Schema.SObjectType> objects = new Set<Schema.SObjectType> {
             	Campaign.SObjectType,
                 CampaignMember.SObjectType
         };
+        if (frUtil.hasNPCobjects()) {
+            objects.add(Account.SObjectType);
+        }
+        return objects;
     }
     
     protected override frUtil.Entity getFrType() {

--- a/src/classes/frCampaignTest.cls
+++ b/src/classes/frCampaignTest.cls
@@ -215,14 +215,24 @@ public class frCampaignTest {
     }
     
     static testMethod void testCampaignMember() {
-        Contact fundraiser = frDonorTest.getTestContact();
+        String supporterId;
+        Id expectedContactId;
+        if (frUtil.hasNPCobjects()) {
+            Account fundraiser = frDonorTest.getTestAccount(true);
+            supporterId = String.valueOf(fundraiser.get('fr_ID__c'));
+            expectedContactId = (Id)fundraiser.get('PersonContactId');
+        } else {
+            Contact fundraiser = frDonorTest.getTestContact();
+            supporterId = fundraiser.fr_ID__c;
+            expectedContactId = fundraiser.Id;
+        }
         
         String goalId = '10';
         String campaignName = 'New Campaign';
         Map<String, Object> request = getTestRequest();
         request.put('name', campaignName);
         request.put('parentGoalId', null);
-        request.put('supporterId', fundraiser.fr_Id__c);
+        request.put('supporterId', supporterId);
         request.put('goalId', goalId);
         
         frTestUtil.createTestPost(request);
@@ -242,7 +252,7 @@ public class frCampaignTest {
         List<CampaignMember> members = [SELECT Id, ContactId, CampaignId FROM CampaignMember WHERE CampaignId = :newCampaign.Id];
         System.assertEquals(1, members.size(), 'There should be a CampaignMember for the Fundraiser');
         CampaignMember fundraiserMember = members.get(0);
-        System.assertEquals(fundraiser.Id, fundraiserMember.ContactId, 'There should be a CampaignMember for the Fundraiser');
+        System.assertEquals(expectedContactId, fundraiserMember.ContactId, 'There should be a CampaignMember for the Fundraiser');
         System.assertEquals(startingErrors, afterErrors, 'No errors were expected, even in the case of duplicate requests');
     }
     


### PR DESCRIPTION
## Summary
- Resolves the campaign-member supporter ContactId from Account.PersonContactId when NPC objects are enabled.
- Keeps the existing Contact lookup behavior for non-NPC Salesforce orgs.
- Updates the existing campaign-member test to validate the expected ContactId for both NPC and non-NPC org shapes.

## Verification
- Not run locally: ant is not installed in this environment.