### PR TITLE
[FUN-17278] Add Salesforce inbound supporter sync

### DIFF
--- a/src/classes/frDonor.cls
+++ b/src/classes/frDonor.cls
@@ -168,6 +168,8 @@ public class frDonor extends frModel implements frSyncable{
             supporter.put('LastName', String.valueOf(request.get('institutionName')));
         }
         // Perform upsert operation
+        Boolean inboundSyncWasDisabled = frInboundSupporterSync.disabled;
+        frInboundSupporterSync.disabled = true;
         try {
             if (supporter.Id != null) {
                 Database.update(supporter, true);
@@ -180,6 +182,8 @@ public class frDonor extends frModel implements frSyncable{
             if (createLogRecord) {
                 frUtil.logException(getFrType(), frId, ex);
             }
+        } finally {
+            frInboundSupporterSync.disabled = inboundSyncWasDisabled;
         }
     
         return result;

--- a/src/classes/frInboundSupporterSync.cls
+++ b/src/classes/frInboundSupporterSync.cls
@@ -1,0 +1,194 @@
+public class frInboundSupporterSync {
+    public static final String SETTINGS_NAME = 'Default';
+    public static final Integer MAX_CALLOUTS_PER_JOB = 25;
+    public static Boolean disabled = false;
+
+    public class WorkItem {
+        public String funraiseId;
+        public String requestBody;
+
+        public WorkItem(String funraiseId, String requestBody) {
+            this.funraiseId = funraiseId;
+            this.requestBody = requestBody;
+        }
+    }
+
+    public static void handleContacts(List<Contact> newRecords, Map<Id, Contact> oldMap) {
+        if (disabled || frUtil.hasNPCobjects() || !isConfigured(getSettings())) {
+            return;
+        }
+
+        Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields('Contact');
+        List<WorkItem> workItems = new List<WorkItem>();
+        for (Contact contact : newRecords) {
+            WorkItem workItem = buildContactWorkItem(contact, oldMap.get(contact.Id), fields);
+            if (workItem != null) {
+                workItems.add(workItem);
+            }
+        }
+
+        enqueue(workItems);
+    }
+
+    public static void handleAccounts(List<Account> newRecords, Map<Id, Account> oldMap) {
+        if (disabled || !frUtil.hasNPCobjects() || !isConfigured(getSettings())) {
+            return;
+        }
+
+        Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields('Account');
+        List<WorkItem> workItems = new List<WorkItem>();
+        for (Account account : newRecords) {
+            WorkItem workItem = buildAccountWorkItem(account, oldMap.get(account.Id), fields);
+            if (workItem != null) {
+                workItems.add(workItem);
+            }
+        }
+
+        enqueue(workItems);
+    }
+
+    public static frInboundSettings__c getSettings() {
+        return frInboundSettings__c.getInstance(SETTINGS_NAME);
+    }
+
+    public static Boolean isConfigured(frInboundSettings__c settings) {
+        return settings != null
+            && settings.Enabled__c == true
+            && String.isNotBlank(settings.Named_Credential__c)
+            && String.isNotBlank(settings.Organization_UUID__c)
+            && String.isNotBlank(settings.Secret__c);
+    }
+
+    private static WorkItem buildContactWorkItem(Contact contact, Contact oldContact, Map<String, Schema.SObjectField> fields) {
+        if (!hasField(fields, 'fr_id__c')) {
+            return null;
+        }
+
+        String funraiseId = stringValue(getFieldValue(contact, fields, 'fr_id__c'));
+        if (String.isBlank(funraiseId)) {
+            return null;
+        }
+
+        Map<String, Object> body = new Map<String, Object>();
+        addChangedField(body, contact, oldContact, fields, 'email', 'email');
+        addChangedField(body, contact, oldContact, fields, 'phone', 'phone');
+        addChangedField(body, contact, oldContact, fields, 'firstname', 'firstName');
+        addChangedField(body, contact, oldContact, fields, 'lastname', 'lastName');
+        addChangedField(body, contact, oldContact, fields, 'mailingstreet', 'address1');
+        addChangedField(body, contact, oldContact, fields, 'mailingcity', 'city');
+        addChangedField(body, contact, oldContact, fields, 'mailingstate', 'state');
+        addChangedField(body, contact, oldContact, fields, 'mailingpostalcode', 'postalCode');
+        addChangedField(body, contact, oldContact, fields, 'mailingcountry', 'country');
+
+        if (body.isEmpty()) {
+            return null;
+        }
+        return new WorkItem(funraiseId, JSON.serialize(body));
+    }
+
+    private static WorkItem buildAccountWorkItem(Account account, Account oldAccount, Map<String, Schema.SObjectField> fields) {
+        if (hasField(fields, 'ispersonaccount')) {
+            Boolean isPersonAccount = (Boolean)getFieldValue(account, fields, 'ispersonaccount');
+            if (isPersonAccount != true) {
+                return null;
+            }
+        }
+
+        if (!hasField(fields, 'fr_id__c')) {
+            return null;
+        }
+
+        String funraiseId = stringValue(getFieldValue(account, fields, 'fr_id__c'));
+        if (String.isBlank(funraiseId)) {
+            return null;
+        }
+
+        Map<String, Object> body = new Map<String, Object>();
+        addChangedField(body, account, oldAccount, fields, 'personemail', 'email');
+        addChangedField(body, account, oldAccount, fields, 'phone', 'phone');
+        addChangedField(body, account, oldAccount, fields, 'firstname', 'firstName');
+        addChangedField(body, account, oldAccount, fields, 'lastname', 'lastName');
+        addChangedField(body, account, oldAccount, fields, 'personmailingstreet', 'address1');
+        addChangedField(body, account, oldAccount, fields, 'personmailingcity', 'city');
+        addChangedField(body, account, oldAccount, fields, 'personmailingstate', 'state');
+        addChangedField(body, account, oldAccount, fields, 'personmailingpostalcode', 'postalCode');
+        addChangedField(body, account, oldAccount, fields, 'personmailingcountry', 'country');
+
+        if (body.isEmpty()) {
+            return null;
+        }
+        return new WorkItem(funraiseId, JSON.serialize(body));
+    }
+
+    private static void addChangedField(
+        Map<String, Object> body,
+        SObject currentRecord,
+        SObject oldRecord,
+        Map<String, Schema.SObjectField> fields,
+        String salesforceField,
+        String funraiseField
+    ) {
+        if (!hasField(fields, salesforceField)) {
+            return;
+        }
+
+        Object currentValue = getFieldValue(currentRecord, fields, salesforceField);
+        Object oldValue = oldRecord == null ? null : getFieldValue(oldRecord, fields, salesforceField);
+        if (!valuesEqual(currentValue, oldValue)) {
+            body.put(funraiseField, currentValue);
+        }
+    }
+
+    private static Boolean valuesEqual(Object currentValue, Object oldValue) {
+        if (currentValue == null && oldValue == null) {
+            return true;
+        }
+        if (currentValue == null || oldValue == null) {
+            return false;
+        }
+        return String.valueOf(currentValue) == String.valueOf(oldValue);
+    }
+
+    private static void enqueue(List<WorkItem> workItems) {
+        if (workItems.isEmpty()) {
+            return;
+        }
+
+        Integer availableJobs = Limits.getLimitQueueableJobs() - Limits.getQueueableJobs();
+        Integer enqueuedJobs = 0;
+        Integer index = 0;
+        while (index < workItems.size() && enqueuedJobs < availableJobs) {
+            Integer endIndex = Math.min(index + MAX_CALLOUTS_PER_JOB, workItems.size());
+            List<WorkItem> chunk = new List<WorkItem>();
+            for (Integer chunkIndex = index; chunkIndex < endIndex; chunkIndex++) {
+                chunk.add(workItems.get(chunkIndex));
+            }
+            System.enqueueJob(new frInboundSupporterSyncJob(chunk));
+            enqueuedJobs++;
+            index += MAX_CALLOUTS_PER_JOB;
+        }
+
+        if (index < workItems.size()) {
+            frUtil.logError(
+                frUtil.Entity.SUPPORTER,
+                workItems.get(index).funraiseId,
+                'Salesforce supporter update sync skipped '
+                    + String.valueOf(workItems.size() - index)
+                    + ' record(s) because the Queueable job limit was reached'
+            );
+        }
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static Boolean hasField(Map<String, Schema.SObjectField> fields, String fieldName) {
+        return fields.containsKey(fieldName.toLowerCase());
+    }
+
+    private static Object getFieldValue(SObject record, Map<String, Schema.SObjectField> fields, String fieldName) {
+        Schema.SObjectField field = fields.get(fieldName.toLowerCase());
+        return field == null ? null : record.get(field.getDescribe().getName());
+    }
+}

--- a/src/classes/frInboundSupporterSync.cls
+++ b/src/classes/frInboundSupporterSync.cls
@@ -1,5 +1,6 @@
 public class frInboundSupporterSync {
     public static final String SETTINGS_NAME = 'Default';
+    public static final String DEFAULT_NAMED_CREDENTIAL = 'Funraise_Platform';
     public static final Integer MAX_CALLOUTS_PER_JOB = 25;
     public static Boolean disabled = false;
 

--- a/src/classes/frInboundSupporterSync.cls-meta.xml
+++ b/src/classes/frInboundSupporterSync.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frInboundSupporterSyncJob.cls
+++ b/src/classes/frInboundSupporterSyncJob.cls
@@ -1,0 +1,52 @@
+public class frInboundSupporterSyncJob implements Queueable, Database.AllowsCallouts {
+    private static final String SECRET_HEADER = 'X-Funraise-Salesforce-Secret';
+    private static final Integer TIMEOUT_MILLISECONDS = 4000;
+    private List<frInboundSupporterSync.WorkItem> workItems;
+
+    public frInboundSupporterSyncJob(List<frInboundSupporterSync.WorkItem> workItems) {
+        this.workItems = workItems == null ? new List<frInboundSupporterSync.WorkItem>() : workItems;
+    }
+
+    public void execute(QueueableContext context) {
+        frInboundSettings__c settings = frInboundSupporterSync.getSettings();
+        if (!frInboundSupporterSync.isConfigured(settings)) {
+            return;
+        }
+
+        Http http = new Http();
+        for (frInboundSupporterSync.WorkItem workItem : workItems) {
+            sendUpdate(http, settings, workItem);
+        }
+    }
+
+    private static void sendUpdate(Http http, frInboundSettings__c settings, frInboundSupporterSync.WorkItem workItem) {
+        try {
+            HttpRequest request = new HttpRequest();
+            request.setMethod('POST');
+            request.setEndpoint(endpoint(settings, workItem.funraiseId));
+            request.setTimeout(TIMEOUT_MILLISECONDS);
+            request.setHeader('Content-Type', 'application/json');
+            request.setHeader(SECRET_HEADER, settings.Secret__c.trim());
+            request.setBody(workItem.requestBody);
+
+            HttpResponse response = http.send(request);
+            if (response.getStatusCode() < 200 || response.getStatusCode() >= 300) {
+                frUtil.logError(
+                    frUtil.Entity.SUPPORTER,
+                    workItem.funraiseId,
+                    'Salesforce supporter update sync failed. Status: ' + response.getStatusCode() + '. Body: ' + response.getBody()
+                );
+            }
+        } catch (Exception ex) {
+            frUtil.logException(frUtil.Entity.SUPPORTER, workItem.funraiseId, ex);
+        }
+    }
+
+    private static String endpoint(frInboundSettings__c settings, String funraiseId) {
+        return 'callout:' + settings.Named_Credential__c.trim()
+            + '/api/v1/salesforce/inbound/'
+            + EncodingUtil.urlEncode(settings.Organization_UUID__c.trim(), 'UTF-8')
+            + '/supporter/'
+            + EncodingUtil.urlEncode(funraiseId, 'UTF-8');
+    }
+}

--- a/src/classes/frInboundSupporterSyncJob.cls-meta.xml
+++ b/src/classes/frInboundSupporterSyncJob.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frInboundSupporterSyncTest.cls
+++ b/src/classes/frInboundSupporterSyncTest.cls
@@ -117,7 +117,7 @@ public class frInboundSupporterSyncTest {
         return new frInboundSettings__c(
             Name = frInboundSupporterSync.SETTINGS_NAME,
             Enabled__c = enabled,
-            Named_Credential__c = 'Funraise_Platform',
+            Named_Credential__c = frInboundSupporterSync.DEFAULT_NAMED_CREDENTIAL,
             Organization_UUID__c = '00000000-0000-0000-0000-000000000001',
             Secret__c = 'shared-secret'
         );

--- a/src/classes/frInboundSupporterSyncTest.cls
+++ b/src/classes/frInboundSupporterSyncTest.cls
@@ -1,0 +1,132 @@
+@IsTest
+public class frInboundSupporterSyncTest {
+    private static Integer calls = 0;
+    private static String endpoint;
+    private static String secret;
+    private static String body;
+
+    private class InboundSyncMock implements HttpCalloutMock {
+        public HttpResponse respond(HttpRequest request) {
+            calls++;
+            endpoint = request.getEndpoint();
+            secret = request.getHeader('X-Funraise-Salesforce-Secret');
+            body = request.getBody();
+
+            HttpResponse response = new HttpResponse();
+            response.setStatusCode(200);
+            response.setBody('{}');
+            return response;
+        }
+    }
+
+    @IsTest
+    static void contactUpdateSyncsAllowlistedFields() {
+        if (frUtil.hasNPCobjects()) {
+            return;
+        }
+
+        insert settings(true);
+        Contact contact = new Contact(
+            FirstName = 'Original',
+            LastName = 'Supporter',
+            Email = 'original@example.org',
+            fr_ID__c = '123'
+        );
+        insert contact;
+
+        resetMock();
+        Test.setMock(HttpCalloutMock.class, new InboundSyncMock());
+
+        Test.startTest();
+        contact.Email = 'updated@example.org';
+        contact.Phone = '555-1234';
+        update contact;
+        Test.stopTest();
+
+        System.assertEquals(1, calls, 'One supporter update should be sent to Funraise');
+        System.assertEquals(
+            'callout:Funraise_Platform/api/v1/salesforce/inbound/00000000-0000-0000-0000-000000000001/supporter/123',
+            endpoint
+        );
+        System.assertEquals('shared-secret', secret);
+
+        Map<String, Object> parsedBody = (Map<String, Object>)JSON.deserializeUntyped(body);
+        System.assertEquals('updated@example.org', parsedBody.get('email'));
+        System.assertEquals('555-1234', parsedBody.get('phone'));
+    }
+
+    @IsTest
+    static void contactUpdateDoesNotSyncWhenDisabled() {
+        if (frUtil.hasNPCobjects()) {
+            return;
+        }
+
+        insert settings(false);
+        Contact contact = new Contact(LastName = 'Supporter', fr_ID__c = '123');
+        insert contact;
+
+        resetMock();
+        Test.setMock(HttpCalloutMock.class, new InboundSyncMock());
+
+        Test.startTest();
+        contact.Phone = '555-1234';
+        update contact;
+        Test.stopTest();
+
+        System.assertEquals(0, calls, 'Disabled inbound sync should not enqueue a callout');
+    }
+
+    @IsTest
+    static void contactUpdateDoesNotSyncWhenSuppressed() {
+        if (frUtil.hasNPCobjects()) {
+            return;
+        }
+
+        insert settings(true);
+        Contact contact = new Contact(LastName = 'Supporter', fr_ID__c = '123');
+        insert contact;
+
+        resetMock();
+        Test.setMock(HttpCalloutMock.class, new InboundSyncMock());
+
+        frInboundSupporterSync.disabled = true;
+        try {
+            Test.startTest();
+            contact.Phone = '555-1234';
+            update contact;
+            Test.stopTest();
+        } finally {
+            frInboundSupporterSync.disabled = false;
+        }
+
+        System.assertEquals(0, calls, 'Suppressed inbound sync should not enqueue a callout');
+    }
+
+    @IsTest
+    static void accountTriggerDelegatesWithoutCalloutWhenUnconfigured() {
+        Account account = new Account(Name = 'Funraise Test Account');
+        insert account;
+
+        Test.startTest();
+        account.Name = 'Funraise Test Account Updated';
+        update account;
+        Test.stopTest();
+    }
+
+    private static frInboundSettings__c settings(Boolean enabled) {
+        return new frInboundSettings__c(
+            Name = frInboundSupporterSync.SETTINGS_NAME,
+            Enabled__c = enabled,
+            Named_Credential__c = 'Funraise_Platform',
+            Organization_UUID__c = '00000000-0000-0000-0000-000000000001',
+            Secret__c = 'shared-secret'
+        );
+    }
+
+    private static void resetMock() {
+        calls = 0;
+        endpoint = null;
+        secret = null;
+        body = null;
+    }
+}

--- a/src/classes/frInboundSupporterSyncTest.cls-meta.xml
+++ b/src/classes/frInboundSupporterSyncTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -82,6 +82,8 @@ public with sharing class frSetupController {
 
 	public Boolean personAccountsEnabled { get; set; }
 	public Boolean isNonProfitOrg { get; set; }
+	public frInboundSettings__c inboundSettings { get; set; }
+	private String existingInboundSecret;
 	
 	public frSetupController() {
 		SelectOption noneOption = new SelectOption('', '--None--');
@@ -174,6 +176,17 @@ public with sharing class frSetupController {
 		donationMappings = frDonation.mappings;
 		donorMappings = frDonor.mappings;
 		giftCommitmentMappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :GIFT_COMMITMENT_TYPE ORDER BY CreatedDate];
+		inboundSettings = frInboundSettings__c.getInstance(frInboundSupporterSync.SETTINGS_NAME);
+		if(inboundSettings == null) {
+			inboundSettings = new frInboundSettings__c(Name = frInboundSupporterSync.SETTINGS_NAME);
+		}
+		if(String.isBlank(inboundSettings.Name)) {
+			inboundSettings.Name = frInboundSupporterSync.SETTINGS_NAME;
+		}
+		if(String.isBlank(inboundSettings.Named_Credential__c)) {
+			inboundSettings.Named_Credential__c = 'Funraise_Platform';
+		}
+		existingInboundSecret = inboundSettings.Secret__c;
 	}
 
 	public void addMapping() {
@@ -246,6 +259,30 @@ public with sharing class frSetupController {
 			upsert upsertList;
 			addConfirm('Mappings saved successfully');
 		}
+	}
+
+	public void saveInboundSettings() {
+		if(inboundSettings == null) {
+			return;
+		}
+
+		if(String.isBlank(inboundSettings.Name)) {
+			inboundSettings.Name = frInboundSupporterSync.SETTINGS_NAME;
+		}
+
+		Schema.DescribeSObjectResult describe = frInboundSettings__c.sObjectType.getDescribe();
+		if(!describe.isCreateable() || !describe.isUpdateable()) {
+			addError('Inbound sync settings not saved. You do not have permission to update inbound sync settings');
+			return;
+		}
+
+		if(String.isBlank(inboundSettings.Secret__c) && String.isNotBlank(existingInboundSecret)) {
+			inboundSettings.Secret__c = existingInboundSecret;
+		}
+
+		upsert inboundSettings;
+		existingInboundSecret = inboundSettings.Secret__c;
+		addConfirm('Inbound sync settings saved successfully');
 	}
 
 	public PageReference cancel() {

--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -184,7 +184,7 @@ public with sharing class frSetupController {
 			inboundSettings.Name = frInboundSupporterSync.SETTINGS_NAME;
 		}
 		if(String.isBlank(inboundSettings.Named_Credential__c)) {
-			inboundSettings.Named_Credential__c = 'Funraise_Platform';
+			inboundSettings.Named_Credential__c = frInboundSupporterSync.DEFAULT_NAMED_CREDENTIAL;
 		}
 		existingInboundSecret = inboundSettings.Secret__c;
 	}

--- a/src/classes/frSetupControllerTest.cls
+++ b/src/classes/frSetupControllerTest.cls
@@ -93,6 +93,46 @@ public class frSetupControllerTest {
 	}
 
 	@IsTest
+	static void test_saveInboundSettings() {
+		frSetupController controller = new frSetupController();
+		controller.inboundSettings.Enabled__c = true;
+		controller.inboundSettings.Named_Credential__c = 'Funraise_Platform';
+		controller.inboundSettings.Organization_UUID__c = '00000000-0000-0000-0000-000000000001';
+		controller.inboundSettings.Secret__c = 'shared-secret';
+
+		Test.startTest();
+		controller.saveInboundSettings();
+		Test.stopTest();
+
+		frInboundSettings__c actual = frInboundSettings__c.getInstance(frInboundSupporterSync.SETTINGS_NAME);
+		System.assertEquals(true, actual.Enabled__c, 'Inbound sync should be enabled');
+		System.assertEquals('Funraise_Platform', actual.Named_Credential__c, 'Named Credential should be saved');
+		System.assertEquals('00000000-0000-0000-0000-000000000001', actual.Organization_UUID__c, 'Organization UUID should be saved');
+		System.assertEquals('shared-secret', actual.Secret__c, 'Inbound secret should be saved');
+	}
+
+	@IsTest
+	static void test_saveInboundSettingsPreservesExistingSecretWhenBlank() {
+		insert new frInboundSettings__c(
+			Name = frInboundSupporterSync.SETTINGS_NAME,
+			Enabled__c = true,
+			Named_Credential__c = 'Funraise_Platform',
+			Organization_UUID__c = '00000000-0000-0000-0000-000000000001',
+			Secret__c = 'existing-secret'
+		);
+
+		frSetupController controller = new frSetupController();
+		controller.inboundSettings.Secret__c = '';
+
+		Test.startTest();
+		controller.saveInboundSettings();
+		Test.stopTest();
+
+		frInboundSettings__c actual = frInboundSettings__c.getInstance(frInboundSupporterSync.SETTINGS_NAME);
+		System.assertEquals('existing-secret', actual.Secret__c, 'Blank password submission should preserve existing secret');
+	}
+
+	@IsTest
 	static void test_removeMapping() {
 		Test.startTest();
 		frSetupController controller = new frSetupController();

--- a/src/classes/frSetupControllerTest.cls
+++ b/src/classes/frSetupControllerTest.cls
@@ -96,7 +96,7 @@ public class frSetupControllerTest {
 	static void test_saveInboundSettings() {
 		frSetupController controller = new frSetupController();
 		controller.inboundSettings.Enabled__c = true;
-		controller.inboundSettings.Named_Credential__c = 'Funraise_Platform';
+		controller.inboundSettings.Named_Credential__c = frInboundSupporterSync.DEFAULT_NAMED_CREDENTIAL;
 		controller.inboundSettings.Organization_UUID__c = '00000000-0000-0000-0000-000000000001';
 		controller.inboundSettings.Secret__c = 'shared-secret';
 
@@ -106,7 +106,7 @@ public class frSetupControllerTest {
 
 		frInboundSettings__c actual = frInboundSettings__c.getInstance(frInboundSupporterSync.SETTINGS_NAME);
 		System.assertEquals(true, actual.Enabled__c, 'Inbound sync should be enabled');
-		System.assertEquals('Funraise_Platform', actual.Named_Credential__c, 'Named Credential should be saved');
+		System.assertEquals(frInboundSupporterSync.DEFAULT_NAMED_CREDENTIAL, actual.Named_Credential__c, 'Named Credential should be saved');
 		System.assertEquals('00000000-0000-0000-0000-000000000001', actual.Organization_UUID__c, 'Organization UUID should be saved');
 		System.assertEquals('shared-secret', actual.Secret__c, 'Inbound secret should be saved');
 	}
@@ -116,7 +116,7 @@ public class frSetupControllerTest {
 		insert new frInboundSettings__c(
 			Name = frInboundSupporterSync.SETTINGS_NAME,
 			Enabled__c = true,
-			Named_Credential__c = 'Funraise_Platform',
+			Named_Credential__c = frInboundSupporterSync.DEFAULT_NAMED_CREDENTIAL,
 			Organization_UUID__c = '00000000-0000-0000-0000-000000000001',
 			Secret__c = 'existing-secret'
 		);

--- a/src/namedCredentials/Funraise_Platform.namedCredential
+++ b/src/namedCredentials/Funraise_Platform.namedCredential
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NamedCredential xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowMergeFieldsInBody>false</allowMergeFieldsInBody>
+    <allowMergeFieldsInHeader>false</allowMergeFieldsInHeader>
+    <endpoint>https://platform.funraise.io</endpoint>
+    <generateAuthorizationHeader>false</generateAuthorizationHeader>
+    <label>Funraise Platform</label>
+    <principalType>Anonymous</principalType>
+    <protocol>NoAuthentication</protocol>
+</NamedCredential>

--- a/src/objects/frInboundSettings__c.object
+++ b/src/objects/frInboundSettings__c.object
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>List</customSettingsType>
+    <enableFeeds>false</enableFeeds>
+    <fields>
+        <fullName>Enabled__c</fullName>
+        <defaultValue>false</defaultValue>
+        <deprecated>false</deprecated>
+        <description>Controls whether Salesforce supporter updates are sent back to Funraise.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Controls whether Salesforce supporter updates are sent back to Funraise.</inlineHelpText>
+        <label>Enabled</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
+        <fullName>Named_Credential__c</fullName>
+        <deprecated>false</deprecated>
+        <description>The API name of the Named Credential that points at the Funraise Platform API.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The API name of the Named Credential that points at the Funraise Platform API.</inlineHelpText>
+        <label>Named Credential</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Organization_UUID__c</fullName>
+        <deprecated>false</deprecated>
+        <description>The Funraise organization UUID used by the inbound Platform endpoint.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The Funraise organization UUID used by the inbound Platform endpoint.</inlineHelpText>
+        <label>Organization UUID</label>
+        <length>36</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Secret__c</fullName>
+        <deprecated>false</deprecated>
+        <description>The shared secret Platform requires on inbound Salesforce sync requests.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The shared secret Platform requires on inbound Salesforce sync requests.</inlineHelpText>
+        <label>Secret</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <label>Funraise Inbound Sync Settings</label>
+    <visibility>Protected</visibility>
+</CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -18,6 +18,9 @@
         <members>frFundraisingEventRegistration</members>
         <members>frFundraisingEventRegistrationTest</members>
         <members>frFundraisingEventTest</members>
+        <members>frInboundSupporterSync</members>
+        <members>frInboundSupporterSyncJob</members>
+        <members>frInboundSupporterSyncTest</members>
         <members>frModel</members>
         <members>frOpportunityPledgeCalculatorTriggerTest</members>
         <members>frPledge</members>
@@ -58,6 +61,8 @@
         <name>ApexPage</name>
     </types>
     <types>
+        <members>frAccountInboundSync</members>
+        <members>frContactInboundSync</members>
         <members>frOpportunityPledgeCalculator</members>
         <name>ApexTrigger</name>
     </types>
@@ -92,6 +97,7 @@
         <members>Sync_Attempt__c</members>
         <members>Sync_Attempt__c</members>
         <members>frField__mdt</members>
+        <members>frInboundSettings__c</members>
         <members>frMapping__c</members>
         <name>CustomObject</name>
     </types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -87,6 +87,10 @@
         <name>CustomMetadata</name>
     </types>
     <types>
+        <members>Funraise_Platform</members>
+        <name>NamedCredential</name>
+    </types>
+    <types>
         <members>Answer__c</members>
         <members>Error__c</members>
         <members>Fundraising_Event_Registration__c</members>

--- a/src/pages/frSetup.page
+++ b/src/pages/frSetup.page
@@ -33,6 +33,17 @@
                 If not, you can select a field value that comes from Funraise
             </h2>
         </apex:pageBlock>
+            <apex:pageBlock title="Salesforce --> Funraise Supporter Sync">
+                <apex:pageBlockButtons location="top">
+                    <apex:commandButton action="{!saveInboundSettings}" value="Save Settings" />
+                </apex:pageBlockButtons>
+                <apex:pageBlockSection columns="1">
+                    <apex:inputField value="{!inboundSettings.Enabled__c}" />
+                    <apex:inputField value="{!inboundSettings.Named_Credential__c}" />
+                    <apex:inputField value="{!inboundSettings.Organization_UUID__c}" />
+                    <apex:inputSecret value="{!inboundSettings.Secret__c}" redisplay="false" />
+                </apex:pageBlockSection>
+            </apex:pageBlock>
         <apex:pageBlock title="Donation --> Opportunity" rendered="{!isNonProfitOrg == false}">
             <apex:pageBlockButtons location="top">
                 <apex:commandButton action="{!donationDefaults}" value="Use Default Mappings" onclick="return confirm('This will delete your current mappings for donation and replace them with the defaults.  Are you sure you want to continue?');" />

--- a/src/permissionsets/Funraise_Permission_Set.permissionset
+++ b/src/permissionsets/Funraise_Permission_Set.permissionset
@@ -65,6 +65,18 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>frInboundSupporterSync</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>frInboundSupporterSyncJob</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>frInboundSupporterSyncTest</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>frModel</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/src/triggers/frAccountInboundSync.trigger
+++ b/src/triggers/frAccountInboundSync.trigger
@@ -1,0 +1,3 @@
+trigger frAccountInboundSync on Account (after update) {
+    frInboundSupporterSync.handleAccounts(Trigger.new, Trigger.oldMap);
+}

--- a/src/triggers/frAccountInboundSync.trigger-meta.xml
+++ b/src/triggers/frAccountInboundSync.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/src/triggers/frContactInboundSync.trigger
+++ b/src/triggers/frContactInboundSync.trigger
@@ -1,0 +1,3 @@
+trigger frContactInboundSync on Contact (after update) {
+    frInboundSupporterSync.handleContacts(Trigger.new, Trigger.oldMap);
+}

--- a/src/triggers/frContactInboundSync.trigger-meta.xml
+++ b/src/triggers/frContactInboundSync.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
Summary
- Adds protected inbound sync settings and setup UI for Platform named credential, organization UUID, shared secret, and enablement.
- Adds Contact and Person Account update handling that sends allowlisted supporter field changes back to Platform.
- Suppresses echo callouts during Funraise-originated donor sync.

Companion Platform PR
- https://bitbucket.org/funraiseio/funraise-mono/pull-requests/4369

Verification
- git diff --check
- sf deploy metadata --metadata-dir /tmp/funraise-salesforce-FUN-17278-validation.zip --single-package --target-org sandbox --dry-run --test-level NoTestRun --wait 30 --concise