### PR TITLE
[FUN-17286] Add configurable NPSP recurring donation target

### DIFF
--- a/src/classes/frDonation.cls
+++ b/src/classes/frDonation.cls
@@ -48,13 +48,13 @@ public class frDonation extends frModel implements frSyncable {
         }
         set;
     }
-    
+
     protected override List<frMapping__c> getMappings() {
         return mappings;
     }
-    
+
     private SObject o;
-    
+
     public frDonation(Sync_Attempt__c syncRecord){
         super(syncRecord);
     }
@@ -72,7 +72,7 @@ public class frDonation extends frModel implements frSyncable {
             List<SObject> gtList = Database.query('SELECT Id, Funraise_GT_Pledge__c, DonorId, CheckDate FROM GiftTransaction WHERE fr_ID__c = :frId');
             if(gtList.isEmpty()) {
                 o = Schema.getGlobalDescribe().get('gifttransaction').newSObject();
-            } 
+            }
             else {
                 o = gtList.get(0);
             }
@@ -83,7 +83,7 @@ public class frDonation extends frModel implements frSyncable {
 
         String funraiseId = getFunraiseId();
         String supporterFunraiseId = String.valueOf(request.get('donorId'));
-        
+
         //connect supporter
         if (String.isNotBlank(supporterFunraiseId)) {
             List<SObject> supporters;
@@ -98,7 +98,7 @@ public class frDonation extends frModel implements frSyncable {
                     o.put('AccountId', supporter.get('AccountId'));
                 }
             } else {
-                if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId,
                                             frUtil.Entity.SUPPORTER, supporterFunraiseId);
             }
         }
@@ -112,7 +112,7 @@ public class frDonation extends frModel implements frSyncable {
                 if (campaigns.size() > 0) {
                     o.put('CampaignId', campaigns[0].Id);
                 } else {
-                    frUtil.logRelationshipError(getFrType(), funraiseId, 
+                    frUtil.logRelationshipError(getFrType(), funraiseId,
                                                 frUtil.Entity.CAMPAIGN, campaignId);
                 }
             }
@@ -120,9 +120,14 @@ public class frDonation extends frModel implements frSyncable {
         //connect subscription
         String subscriptionId = String.valueOf(request.get('subscriptionId'));
         if (String.isNotBlank(subscriptionId)) {
-            List<SObject> subscriptions = Database.query('SELECT Id FROM ' + SUBSCRIPTION_OBJ_NAME + ' WHERE fr_ID__c = :subscriptionId');
+            String subscriptionObjectName = getSubscriptionObjectName();
+            String subscriptionIdFieldName = getSubscriptionIdFieldName();
+            String subscriptionLookupFieldName = getSubscriptionLookupFieldName();
+            List<SObject> subscriptions = Database.query('SELECT Id FROM ' + subscriptionObjectName + ' WHERE ' + subscriptionIdFieldName + ' = :subscriptionId');
             if (subscriptions.size() > 0) {
-                o.put(SUBSCRIPTION_LOOKUP_FIELD_NAME, subscriptions.get(0).get('Id'));
+                if(String.isNotBlank(subscriptionLookupFieldName)) {
+                    o.put(subscriptionLookupFieldName, subscriptions.get(0).get('Id'));
+                }
             } else {
                 frUtil.logRelationshipError(getFrType(), funraiseId,
                                             frUtil.Entity.SUBSCRIPTION, subscriptionId);
@@ -175,14 +180,14 @@ public class frDonation extends frModel implements frSyncable {
             if(frUtil.hasNPCobjects()) frPledge.create(o);
             else frPledge.create((Opportunity) o);
         }
-        
+
         if(o.get('Id') != null && !frUtil.hasNPCobjects()) {
             createOpportunityMapping(request);
         }
 
         return result;
     }
-    
+
     @testVisible
     private Boolean shouldSetOpportunityStage() {
         for(frMapping__c mapping : getMappings()) {
@@ -192,15 +197,15 @@ public class frDonation extends frModel implements frSyncable {
         }
         return true;
     }
-    
+
     @testVisible
     private void setOpportunityStage(Opportunity o, String status) {
         if(shouldSetOpportunityStage()) {
-            List<OpportunityStage> stages = [SELECT Id, MasterLabel, IsWon, IsClosed 
-                                             FROM OpportunityStage 
-                                             WHERE IsActive = true 
+            List<OpportunityStage> stages = [SELECT Id, MasterLabel, IsWon, IsClosed
+                                             FROM OpportunityStage
+                                             WHERE IsActive = true
                                              ORDER BY SortOrder];
-            
+
             //if Closed Won & Closed Lost exist, we'll use those
             //else we'll try to find the best stage
             boolean useDefaultWon = false;
@@ -212,7 +217,7 @@ public class frDonation extends frModel implements frSyncable {
                     useDefaultLost = true;
                 }
             }
-            
+
             if (status == PENDING) {
                 for (OpportunityStage stage : stages) {
                     if(!stage.IsWon && !stage.isClosed) {
@@ -229,7 +234,7 @@ public class frDonation extends frModel implements frSyncable {
                             o.StageName = stage.MasterLabel;
                             break;
                         }
-                    }                    
+                    }
                 }
             } else {
                 if(useDefaultWon) {
@@ -245,24 +250,24 @@ public class frDonation extends frModel implements frSyncable {
             }
         }
     }
-    
+
     private boolean isContactRoleMappingDisabled() {
         return getRequestBody().containsKey(META_OPP_CONTACT_MAPPING_KEY) ?
             Boolean.valueOf(getRequestBody().get(META_OPP_CONTACT_MAPPING_KEY)): true;
     }
-   
-    
+
+
     private void createOpportunityMapping(Map<String, Object> request) {
         Boolean contactRoleMappingDisabled = isContactRoleMappingDisabled();
         if(contactRoleMappingDisabled) {
             return;
         }
-        
+
         String funraiseId = getFunraiseId();
         String supporterId = String.valueOf(request.get('donorId'));
-        
+
         Set<String> relatedSupporterFunraiseIds = new Set<String>{supporterId};
-            
+
         String fundraiserId = request.containsKey('fundraiserId') ? String.valueOf(request.get('fundraiserId')) : null;
         if(String.isNotBlank(fundraiserId)) {
             relatedSupporterFunraiseIds.add(fundraiserId);
@@ -275,21 +280,21 @@ public class frDonation extends frModel implements frSyncable {
         if(String.isNotBlank(softCreditSupporterId)) {
             relatedSupporterFunraiseIds.add(softCreditSupporterId);
         }
-        
+
         Map<String, Contact> relatedContacts = new Map<String, Contact>();
         Set<String> supportersWithContactRoles = new Set<String>();
-        for(Contact relatedContact : [SELECT Id, fr_Id__c, 
-                                      (SELECT Id, Role, ContactId FROM OpportunityContactRoles WHERE OpportunityId = :getSalesforceId()) 
+        for(Contact relatedContact : [SELECT Id, fr_Id__c,
+                                      (SELECT Id, Role, ContactId FROM OpportunityContactRoles WHERE OpportunityId = :getSalesforceId())
                                       from Contact WHERE fr_Id__c IN :relatedSupporterFunraiseIds]) {
                                           relatedContacts.put(relatedContact.fr_Id__c, relatedContact);
                                           if(relatedContact.OpportunityContactRoles.size() > 0) {
                                               supportersWithContactRoles.add(relatedContact.fr_Id__c);
                                           }
                                       }
-        
+
         List<OpportunityContactRole> newContactRoles = new List<OpportunityContactRole>();
 
-        
+
         if(!supportersWithContactRoles.contains(supporterId)) {
             OpportunityContactRole donorRole = createRole(OPP_ROLE_DONOR, supporterId, relatedContacts, funraiseId);
             if(donorRole != null) {
@@ -297,7 +302,7 @@ public class frDonation extends frModel implements frSyncable {
                 supportersWithContactRoles.add(supporterId);
             }
         }
-        
+
         if(!supportersWithContactRoles.contains(fundraiserId)) {
             OpportunityContactRole fundraiserRole = createRole(OPP_ROLE_FUNDRAISER, fundraiserId, relatedContacts, funraiseId);
             if(fundraiserRole != null) {
@@ -305,8 +310,8 @@ public class frDonation extends frModel implements frSyncable {
                 supportersWithContactRoles.add(fundraiserId);
             }
         }
-        
-        
+
+
         if(!supportersWithContactRoles.contains(softCreditSupporterId)) {
             OpportunityContactRole softCreditRole = createRole(OPP_ROLE_SOFT_CREDIT, softCreditSupporterId, relatedContacts, funraiseId);
             if(softCreditRole != null) {
@@ -314,32 +319,32 @@ public class frDonation extends frModel implements frSyncable {
                 supportersWithContactRoles.add(softCreditSupporterId);
             }
         }
-        
+
         if(!supportersWithContactRoles.contains(teamCaptainId)) {
             OpportunityContactRole teamCaptainRole = createRole(OPP_ROLE_TEAM_CAPTAIN, teamCaptainId, relatedContacts, funraiseId);
             if(teamCaptainRole != null) {
                 newContactRoles.add(teamCaptainRole);
             }
         }
-        
+
         try {
             insert newContactRoles;
         } catch (Exception ex) {
             frUtil.logException(getFrType(), funraiseId, ex);
         }
     }
-    
+
     private OpportunityContactRole createRole(String role, String funraiseSupporterId, Map<String, Contact> contactsByFunraiseId, String funraiseDonationId) {
         if(String.isBlank(funraiseSupporterId)) {
             return null;
         }
         if(!contactsByFunraiseId.containsKey(funraiseSupporterId)) {
-            frUtil.logRelationshipError(getFrType(), funraiseDonationId, 
+            frUtil.logRelationshipError(getFrType(), funraiseDonationId,
                                         frUtil.Entity.SUPPORTER, funraiseSupporterId,
                                         'Opportunity Contact Role: '+ role);
             return null;
         }
-        
+
         Contact supporter = contactsByFunraiseId.get(funraiseSupporterId);
         OpportunityContactRole newRole = new OpportunityContactRole();
         newRole.ContactId = supporter.Id;
@@ -347,16 +352,16 @@ public class frDonation extends frModel implements frSyncable {
         newRole.Role = role;
         return newRole;
     }
-    
+
     protected override String getSalesforceId(){
         if(frUtil.hasNPCobjects()) {
-            return this.o != null ? (String) this.o.get('Id') : null; 
+            return this.o != null ? (String) this.o.get('Id') : null;
         }
         else {
             return this.o != null ? this.o.Id : null;
         }
     }
-    
+
     protected override Set<Schema.SObjectField> getFields() {
         Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(Opportunity.sObjectType.getDescribe().getName());
         Set<Schema.SObjectField> usedFields = new Set<Schema.SObjectField>();
@@ -368,7 +373,11 @@ public class frDonation extends frModel implements frSyncable {
         usedFields.add(Opportunity.StageName);
         usedFields.add(Opportunity.AccountId);
         usedFields.add(Opportunity.fr_Donor__c);
-        usedFields.add(Opportunity.Subscription__c);
+        if(frUtil.usesNPSPRecurringDonations() && fields.containsKey(frUtil.NPSP_RECURRING_DONATION_OPPORTUNITY_LOOKUP_FIELD_NAME)) {
+            usedFields.add(fields.get(frUtil.NPSP_RECURRING_DONATION_OPPORTUNITY_LOOKUP_FIELD_NAME));
+        } else {
+            usedFields.add(Opportunity.Subscription__c);
+        }
         usedFields.add(Opportunity.Funraise_Pledge__c);
         if(!isContactRoleMappingDisabled()) {
             usedFields.add(OpportunityContactRole.ContactId);
@@ -389,7 +398,7 @@ public class frDonation extends frModel implements frSyncable {
         }
         return usedFields;
     }
-    
+
     protected override Set<Schema.SObjectType> getObjects() {
         Set<Schema.SObjectType> usedObjects = new Set<Schema.SObjectType>();
         if(!frUtil.hasNPCobjects()) {
@@ -403,21 +412,50 @@ public class frDonation extends frModel implements frSyncable {
         }
         return usedObjects;
     }
-    
+
     protected override frUtil.Entity getFrType() {
         return frUtil.Entity.DONATION;
     }
-    
+
     protected override String getUpdtimeJsonKey() {
         return 'donation_updtime';
+    }
+
+    private String getSubscriptionObjectName() {
+        if(frUtil.hasNPCobjects()) {
+            return 'GiftCommitment';
+        }
+        if(frUtil.usesNPSPRecurringDonations()) {
+            return frUtil.NPSP_RECURRING_DONATION_OBJ_NAME;
+        }
+        return 'Subscription__c';
+    }
+
+    private String getSubscriptionIdFieldName() {
+        if(frUtil.usesNPSPRecurringDonations() && !frUtil.hasNPCobjects()) {
+            return frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME;
+        }
+        return 'fr_ID__c';
+    }
+
+    private String getSubscriptionLookupFieldName() {
+        if(frUtil.hasNPCobjects()) {
+            return 'GiftCommitmentId';
+        }
+        if(frUtil.usesNPSPRecurringDonations()) {
+            Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(Opportunity.sObjectType.getDescribe().getName());
+            if(fields.containsKey(frUtil.NPSP_RECURRING_DONATION_OPPORTUNITY_LOOKUP_FIELD_NAME)) {
+                return frUtil.NPSP_RECURRING_DONATION_OPPORTUNITY_LOOKUP_FIELD_NAME;
+            }
+            return null;
+        }
+        return 'Subscription__c';
     }
 
     ///CONSTANTS///
 
     public static final String TYPE = 'Donation';
     public static final String SUPPORTER_OBJ_NAME = frUtil.hasNPCobjects() ? 'Account' : 'Contact';
-    public static final String SUBSCRIPTION_OBJ_NAME = frUtil.hasNPCobjects() ? 'GiftCommitment' : 'Subscription__c';
-    public static final String SUBSCRIPTION_LOOKUP_FIELD_NAME = frUtil.hasNPCobjects() ? 'GiftCommitmentId' : 'Subscription__c';
     public static final String PLEDGE_LOOKUP_FIELD_NAME = frUtil.hasNPCobjects() ? 'Funraise_GT_Pledge__c' : 'Funraise_Pledge__c';
 
     //Donation statuses
@@ -425,17 +463,17 @@ public class frDonation extends frModel implements frSyncable {
     private static final String PENDING = 'Pending';
     private static final String REFUNDED = 'Refunded';
     private static final String FAILED = 'Failed';
-    
+
     //Default Opportunity Stages
     private static final String CLOSED_WON = 'Closed Won';
     private static final String CLOSED_LOST = 'Closed Lost';
-    
+
     //Opportunity Contact Role types
     @TestVisible private static final String OPP_ROLE_DONOR = 'Donor';
     @TestVisible private static final String OPP_ROLE_FUNDRAISER = 'Fundraiser';
     @TestVisible private static final String OPP_ROLE_TEAM_CAPTAIN = 'Team Captain';
     @TestVisible private static final String OPP_ROLE_SOFT_CREDIT = 'Soft Credit';
-    
+
     private static final String META_OPP_CONTACT_MAPPING_KEY = 'opportunityContactMappingDisabled';
     private static final String META_CAMPAIGN_MAPPING_KEY = 'campaignMappingDisabled';
 }

--- a/src/classes/frDonationTest.cls
+++ b/src/classes/frDonationTest.cls
@@ -39,8 +39,8 @@
 */
 @isTest
 public class frDonationTest {
-    
-    
+
+
     static testMethod void syncEntity_newDonor() {
         if (frUtil.hasNPCobjects()) {
             return; // skip in NPC org
@@ -49,19 +49,19 @@ public class frDonationTest {
         createMapping('name', 'Description');
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         insert new frMapping__c(Name = 'Test String', Is_Constant__c = true, Constant_Value__c = 'Closed Won',
                                 sf_Name__c = 'StageName', Type__c = frDonation.TYPE);
         insert new frMapping__c(Name = 'Test Percent', Is_Constant__c = true, Constant_Value__c = '95',
                                 sf_Name__c = 'Probability', Type__c = frDonation.TYPE);
         insert new frMapping__c(Name = 'Test Double', Is_Constant__c = true, Constant_Value__c = '1.5',
                                 sf_Name__c = 'totalopportunityquantity', Type__c = frDonation.TYPE);
-        
+
         frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [
             SELECT Id, fr_ID__c, StageName, Name, Description, Probability, TotalOpportunityQuantity
@@ -71,12 +71,12 @@ public class frDonationTest {
         System.assertEquals('Closed Won', newOpportunity.StageName, 'The constant mapping for StageName was not used');
         System.assertEquals(95, newOpportunity.Probability, 'The constant mapping for Probability was not used');
         System.assertEquals(1.5, newOpportunity.TotalOpportunityQuantity, 'The constant mapping for Total Opportunity Quantity was not used');
-        
+
         String expectedNameAndDesc = String.valueOf(getTestRequest().get('name'));
         System.assertEquals(expectedNameAndDesc, newOpportunity.Name, 'The mapping for name should have been applied');
         System.assertEquals(expectedNameAndDesc, newOpportunity.Description, 'The mapping for desc should have been applied');
     }
-    
+
     static testMethod void syncEntity_newDonor_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return; // skip in non-NPC org
@@ -91,12 +91,12 @@ public class frDonationTest {
         insert new frMapping__c(Name = 'Test Double', Is_Constant__c = true, Constant_Value__c = '1.5',
                                 sf_Name__c = 'totalopportunityquantity', Type__c = frDonation.TYPE);
         insert frSetupController.getGiftTransactionDefaults();
-        
+
         frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         List<SObject> gt = Database.query(
             'SELECT Id, Name, Description '+ //, StageName__c, Probability__c, TotalOpportunityQuantity__c ' +
@@ -106,12 +106,12 @@ public class frDonationTest {
         //System.assertEquals('Closed Won', (String)gt[0].get('StageName__c'));
         //System.assertEquals(95, (Decimal)gt[0].get('Probability__c'));
         //System.assertEquals(1.5, (Decimal)gt[0].get('TotalOpportunityQuantity__c'));
-        
+
         String expectedNameAndDesc = String.valueOf(getTestRequest().get('name'));
         System.assertEquals(expectedNameAndDesc, (String)gt[0].get('Name'));
         System.assertEquals(expectedNameAndDesc, (String)gt[0].get('Description'));
     }
-    
+
     static testMethod void syncEntity_existingDonor() {
         if (frUtil.hasNPCobjects()) {
             return;
@@ -119,13 +119,13 @@ public class frDonationTest {
         Contact testContact = frDonorTest.getTestContact();
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         frTestUtil.createTestPost(getTestRequest());
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [
@@ -136,7 +136,7 @@ public class frDonationTest {
         System.assertEquals(testContact.Id, newOpportunity.fr_Donor__c,
                             'The funraise sf donor id was not populated to the opportunity\'s contact lookup field');
     }
-    
+
     static testMethod void syncEntity_existingDonor_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
@@ -145,15 +145,15 @@ public class frDonationTest {
         Account testAccount = frDonorTest.getTestAccount(true);
         insert frSetupController.getGiftTransactionDefaults();
         createMapping('name', 'Name');
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('donorId', '856');
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         frTestUtil.assertNoErrors();
         List<SObject> gt = Database.query(
@@ -161,8 +161,8 @@ public class frDonationTest {
         );
         System.assertEquals(testAccount.Id, gt[0].get('DonorId'));
     }
-    
-    
+
+
     static testMethod void syncEntity_CampaignDonation() {
         if (frUtil.hasNPCobjects()) {
             return;
@@ -170,20 +170,20 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
         Contact testContact = frDonorTest.getTestContact();
-        
+
         Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('campaignGoalId', 10);
         request.put('campaignMappingDisabled', false);
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [
@@ -196,7 +196,7 @@ public class frDonationTest {
         System.assertEquals(testCampaign.Id, newOpportunity.CampaignId,
                             'The campaign Id was not added to the donation');
     }
-    
+
     static testMethod void syncEntity_CampaignDonation_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
@@ -208,17 +208,17 @@ public class frDonationTest {
         Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         Map<String,Object> req = getTestRequest();
         req.put('donorId', '856');
         req.put('campaignGoalId', 10);
         req.put('campaignMappingDisabled', false);
         frTestUtil.createTestPost(req);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         String oppFrId = String.valueOf(req.get('id'));
         frTestUtil.assertNoErrors();
         List<SObject> gt = Database.query(
@@ -227,43 +227,43 @@ public class frDonationTest {
         System.assertEquals(testAccount.Id, gt[0].get('DonorId'));
         System.assertEquals(testCampaign.Id, gt[0].get('CampaignId'));
     }
-    
-    
+
+
     static testMethod void syncEntity_donationStatusDefaulting() {
         if (frUtil.hasNPCobjects()) {
             return;
         }
         Contact testContact = frDonorTest.getTestContact();
-        
-        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
+
+        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('status', 'Refunded');
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [SELECT Id, StageName, fr_ID__c, fr_Donor__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals('Closed Lost', newOpportunity.StageName, 'A status of refunded should have resulted in a Closed Lost stage');
     }
-    
-    
+
+
     static testMethod void syncEntity_newOpportunityRoleMappings() {
         if (frUtil.hasNPCobjects()) {
             return;
         }
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact donor = frDonorTest.getTestContact(false);
         donor.fr_Id__c = '1';
         donor.Email = 'donor@example.com';
@@ -274,20 +274,20 @@ public class frDonationTest {
         teamCaptain.fr_Id__c = '3';
         teamCaptain.Email = 'teamCaptain@example.com';
         insert new List<Contact>{donor, fundraiser, teamCaptain};
-            
+
             Map<String, Object> request = getTestRequest();
         request.put('opportunityContactMappingDisabled', 'false');
         request.put('donorId', donor.fr_Id__c);
         request.put('fundraiserId', fundraiser.fr_ID__c);
         request.put('teamCaptainId', teamCaptain.fr_ID__c);
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE fr_Id__c = :oppFrId];
         List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
@@ -304,15 +304,15 @@ public class frDonationTest {
             }
         }
     }
-    
-    
+
+
     static testMethod void syncEntity_newOpportunityRoleMappings_missingContacts() {
         if (frUtil.hasNPCobjects()) {
             return;
         }
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact donor = frDonorTest.getTestContact(false);
         donor.fr_Id__c = '1';
         donor.Email = 'donor@example.com';
@@ -323,52 +323,92 @@ public class frDonationTest {
         teamCaptain.fr_Id__c = '3';
         teamCaptain.Email = 'teamCaptain@example.com';
         insert new List<Contact>{donor, fundraiser, teamCaptain};
-            
+
             Map<String, Object> request = getTestRequest();
         request.put('opportunityContactMappingDisabled', 'false');
         request.put('donorId', donor.fr_Id__c);
         request.put('fundraiserId', fundraiser.fr_ID__c+'1');
         request.put('teamCaptainId', teamCaptain.fr_ID__c+'1');
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, fr_Donor__c, (SELECT Id, ContactId, Role FROM OpportunityContactRoles) FROM Opportunity WHERE fr_Id__c = :oppFrId];
         List<OpportunityContactRole> roles = newOpportunity.OpportunityContactRoles;
         System.assertEquals(1, roles.size(), 'Since the request had ids that did not exist in SF, no roles should have been created except for the donor');
         System.assertEquals(2, [SELECT COUNT() FROM Error__c], 'There should be 3 error logs for missing supporters that prevented opp roles from being created');
     }
-    
+
     static testMethod void syncEntity_LinkToSubscription() {
-        if (frUtil.hasNPCobjects()) {
+        if (frUtil.hasNPCobjects() || frUtil.usesNPSPRecurringDonations()) {
             return;
         }
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
-        
+
         Subscription__c subscription = new Subscription__c(Name = 'Test Sub', fr_ID__c = '1234', Supporter__c = testSupporter.Id);
         insert subscription;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('subscriptionId', subscription.fr_ID__c);
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, Subscription__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(subscription.Id, newOpportunity.Subscription__c, 'The new donation should be pointing at the subscription corresponding to the id provided in the request');
     }
-    
+
+    static testMethod void syncEntity_LinkToSubscription_NPSP() {
+        if (frUtil.hasNPCobjects() || !frUtil.hasNPSPRecurringDonations()) {
+            return;
+        }
+        frSubscriptionTest.enableNPSPRecurringDonationTarget();
+        createMapping('name', 'Name');
+        createMapping('donation_cretime', 'CloseDate');
+
+        Contact testSupporter = frDonorTest.getTestContact();
+        String subscriptionFunraiseId = '1234';
+        Map<String, Object> subscriptionRequest = frSubscriptionTest.getTestRequest();
+        subscriptionRequest.put('supporterId', testSupporter.fr_ID__c);
+        subscriptionRequest.put('id', subscriptionFunraiseId);
+        frTestUtil.createTestPost(subscriptionRequest);
+        frWSSubscriptionController.syncEntity();
+
+        Map<String, Object> request = getTestRequest();
+        request.put('donorId', testSupporter.fr_ID__c);
+        request.put('subscriptionId', subscriptionFunraiseId);
+
+        frTestUtil.createTestPost(request);
+        Test.startTest();
+        frWSDonationController.syncEntity();
+        Test.stopTest();
+
+        frTestUtil.assertNoErrors();
+
+        String oppFrId = String.valueOf(getTestRequest().get('id'));
+        List<SObject> recurringDonations = Database.query(
+            'SELECT Id FROM ' + frUtil.NPSP_RECURRING_DONATION_OBJ_NAME +
+            ' WHERE ' + frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME + ' = :subscriptionFunraiseId'
+        );
+        List<SObject> opportunities = Database.query(
+            'SELECT Id, ' + frUtil.NPSP_RECURRING_DONATION_OPPORTUNITY_LOOKUP_FIELD_NAME +
+            ' FROM Opportunity WHERE fr_Id__c = :oppFrId'
+        );
+        System.assertEquals(recurringDonations[0].get('Id'), opportunities[0].get(frUtil.NPSP_RECURRING_DONATION_OPPORTUNITY_LOOKUP_FIELD_NAME),
+            'The new donation should point at the NPSP Recurring Donation corresponding to the id provided in the request');
+    }
+
     static testMethod void syncEntity_LinkToSubscription_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
@@ -377,56 +417,56 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('amount', 'OriginalAmount');
         createMapping('donation_cretime', 'TransactionDueDate');
-        
+
         insert new frMapping__c(Type__c = 'Gift Transaction', Name = 'donation_cretime',
                                 fr_Name__c = 'donation_cretime', sf_Name__c = 'CheckDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonortest.getTestAccount(true);
-        
+
         Subscription__c subscription = new Subscription__c(Name = 'Test Sub', fr_ID__c = '1234', Supporter__c = testSupporter.Id);
         insert subscription;
-        
+
         SObject matchingNPCrecord = Schema.getGlobalDescribe().get('giftcommitment').newSObject();
         matchingNPCrecord.put('fr_ID__c', '1234');
         matchingNPCrecord.put('Name', 'Test Sub');
         matchingNPCrecord.put('DonorId', testAccount.Id);
         insert matchingNPCrecord;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('subscriptionId', subscription.fr_ID__c);
         request.put('opportunityContactMappingDisabled', 'false');
         request.put('donorId', '856');
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         String oppFrId = String.valueOf(request.get('id'));
         frTestUtil.assertNoErrors();
         List<SObject> gt = Database.query('SELECT Id, Name, DonorId, GiftCommitmentId FROM GiftTransaction WHERE fr_ID__c = :oppFrId');
         List<SObject> gc = Database.query('SELECT Id FROM GiftCommitment WHERE fr_ID__c = \'1234\'');
         System.assertEquals(gc[0].Id, gt[0].get('GiftCommitmentId'));
     }
-    
+
     static testMethod void syncEntity_LinkToPledge() {
         if (frUtil.hasNPCobjects()) {
             return;
         }
         createMapping('name', 'Name');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
-        
+
         Pledge__c pledge = getTestPledge(testSupporter);
         insert pledge;
-        
+
         frTestUtil.createTestPost(getTestRequest());
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity newOpportunity = [SELECT Id, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
@@ -467,22 +507,22 @@ public class frDonationTest {
         insert frSetupController.getGiftTransactionDefaults();
         insert new frMapping__c(Type__c = 'Gift Transaction', Name = 'donation_cretime',
                                 fr_Name__c = 'donation_cretime', sf_Name__c = 'CheckDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonortest.getTestAccount(true);
-        
+
         Pledge__c pledge = getTestPledgeAcc(testAccount);
         insert pledge;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('donorId', '856');
         request.put('pledge', true);
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         List<SObject> gt = Database.query('SELECT Id, OriginalAmount, fr_ID__c, Funraise_GT_Pledge__c FROM GiftTransaction');
         System.assertNotEquals(null, gt[0].get('Funraise_GT_Pledge__c'));
     }
@@ -524,17 +564,17 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('pledge', true);
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
@@ -546,29 +586,29 @@ public class frDonationTest {
         System.assertEquals(pledge.Pledge_Amount__c, opp.Amount, 'The pledged amount should be the same as the opportunity amount');
         System.assertEquals(pledge.Received_Amount__c, opp.Amount, 'The receive amount should be the same as the opportunity amount since the opp is Closed Won');
     }
-    
+
     static testMethod void syncEntity_PledgeCreatesPledge_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
         }
         Account testAccount = frDonortest.getTestAccount(true);
-        
+
         createMapping('name', 'Name');
         createMapping('amount', 'OriginalAmount');
         insert frSetupController.getGiftTransactionDefaults();
         insert new frMapping__c(Type__c = 'Gift Transaction', Name = 'donation_cretime',
                                 fr_Name__c = 'donation_cretime', sf_Name__c = 'CheckDate');
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('pledge', true);
         request.put('donorId', '856');
-        
+
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
         List<SObject> gt = Database.query('SELECT Id, OriginalAmount, fr_ID__c, Funraise_GT_Pledge__c FROM GiftTransaction');
         System.assertNotEquals(null, gt[0].get('Funraise_GT_Pledge__c'));
@@ -579,7 +619,7 @@ public class frDonationTest {
         ];
         System.assertEquals(gt[0].get('OriginalAmount'), pledge.Pledge_Amount__c);
     }
-    
+
     //
     // syncEntity_PledgeUpdatesPledge
     //
@@ -591,34 +631,34 @@ public class frDonationTest {
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
         Contact testSupporter = frDonorTest.getTestContact();
-        
+
         Opportunity existingOpp = getTestOpp();
         existingOpp.fr_Id__c = '2048';
         insert existingOpp;
-        
+
         Pledge__c pledge = getTestPledge(testSupporter);
         pledge.Pledge_Donation__c = existingOpp.Id;
         insert pledge;
-        
+
         existingOpp.Funraise_Pledge__c = pledge.Id;
         update existingOpp;
-        
+
         //requery to get the workflow rule update on pledge_donation_uq__c
         pledge = [SELECT Id, Pledge_Donation__c, Pledge_Donation_uq__c FROM Pledge__c WHERE Id = :pledge.Id];
         System.assertEquals(pledge.Pledge_Donation__c +'', pledge.Pledge_Donation_uq__c+'',
                             'The external id unique field should have been updated with the value from the lookup field');
-        
-        
+
+
         Map<String, Object> request = getTestRequest();
         request.put('pledge', true);
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity opp = [SELECT Id, Amount, fr_ID__c, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertNotEquals(null, opp.Funraise_Pledge__c, 'The new donation should have created a new pledge');
@@ -629,48 +669,48 @@ public class frDonationTest {
         System.assertEquals(pledge.Pledge_Amount__c, opp.Amount, 'The pledged amount should be the same as the opportunity amount');
         System.assertEquals(pledge.Received_Amount__c, opp.Amount, 'The receive amount should be the same as the opportunity amount since the opp is Closed Won');
     }
-    
+
     static testMethod void syncEntity_PledgeUpdatesPledge_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
         }
         Account testAccount = frDonorTest.getTestAccount(true);
-        
+
         createMapping('name', 'Name');
         createMapping('amount', 'OriginalAmount');
         insert frSetupController.getGiftTransactionDefaults();
         insert new frMapping__c(Type__c = 'Gift Transaction', Name = 'donation_cretime',
                                 fr_Name__c = 'donation_cretime', sf_Name__c = 'CheckDate');
-        
+
         Opportunity existingOpp = getTestOpp();
         existingOpp.fr_Id__c = '2048';
         insert existingOpp;
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         Pledge__c pledge = getTestPledge(testSupporter);
         pledge.Pledge_Donation__c = existingOpp.Id;
         insert pledge;
-        
+
         SObject existingGT = getTestGT();
         existingGT.put('fr_Id__c', '2048');
         existingGT.put('Funraise_GT_Pledge__c', pledge.Id);
         insert existingGT;
-        
+
         existingOpp.Funraise_Pledge__c = pledge.Id;
         update existingOpp;
         existingGT.put('Funraise_GT_Pledge__c', pledge.Id);
         update existingGT;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('pledge', true);
         request.put('donorId', '856');
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
         frTestUtil.assertNoErrors();
-        
+
         List<SObject> gt = Database.query(
             'SELECT Id, OriginalAmount, fr_ID__c, Funraise_GT_Pledge__c FROM GiftTransaction'
         );
@@ -682,7 +722,7 @@ public class frDonationTest {
         ];
         System.assertEquals(gt[0].get('OriginalAmount'), pledge.Pledge_Amount__c);
     }
-    
+
     //
     // syncEntity_existing_alreadyLinkedToPledge
     //
@@ -693,7 +733,7 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         Pledge__c pledge = getTestPledge(testSupporter);
         pledge.End_Date__c = Date.today().addDays(-1); //so it's no longer active
@@ -702,22 +742,22 @@ public class frDonationTest {
         existingOpp.fr_Id__c = '2048';
         existingOpp.Funraise_Pledge__c = pledge.Id;
         insert existingOpp;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('id', existingOpp.fr_Id__c);
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(pledge.Id, opp.Funraise_Pledge__c, 'The pledge value should remain unchanged');
     }
-    
+
     static testMethod void syncEntity_existing_alreadyLinkedToPledge_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
@@ -726,27 +766,27 @@ public class frDonationTest {
         createMapping('amount', 'OriginalAmount');
         createMapping('donation_cretime', 'CheckDate');
         insert frSetupController.getGiftTransactionDefaults();
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonortest.getTestAccount(true);
         Pledge__c pledge = getTestPledgeAcc(testAccount);
         pledge.End_Date__c = Date.today().addDays(-1);
         insert pledge;
-        
+
         SObject existingGT = getTestGT();
         existingGT.put('fr_Id__c', '2048');
         existingGT.put('Funraise_GT_Pledge__c', pledge.Id);
         insert existingGT;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('id', existingGT.get('fr_Id__c'));
         request.put('donorId', '856');
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         String requestId = (String) request.get('id');
         List<SObject> gc = Database.query(
             'SELECT Id, Funraise_GT_Pledge__c FROM GiftTransaction WHERE fr_ID__c = :requestId'
@@ -802,7 +842,7 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         //get a pledge that is inactive according to dates
         //but is unfulfilled in amount
@@ -810,22 +850,22 @@ public class frDonationTest {
         pledge.Start_Date__c = Date.today().addDays(-5);
         pledge.End_Date__c = Date.today().addDays(-1);
         insert pledge;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('donation_cretime', DateTime.now().addDays(-3).getTime());
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(pledge.Id, opp.Funraise_Pledge__c, 'The donation should have matched to a previously active unfulfilled pledge');
     }
-    
+
     static testMethod void syncEntity_oldDonation_matchesInactivePledge_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
@@ -835,24 +875,24 @@ public class frDonationTest {
         //createMapping('donation_cretime', 'TransactionDueDate');
         createMapping('donation_cretime', 'CheckDate');
         insert frSetupController.getGiftTransactionDefaults();
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonortest.getTestAccount(true);
         Pledge__c pledge = getTestPledgeAcc(testAccount);
         pledge.Start_Date__c = Date.today().addDays(-5);
         pledge.End_Date__c = Date.today().addDays(-1);
         insert pledge;
-        
+
         Map<String, Object> req = getTestRequest();
         req.put('donation_cretime', DateTime.now().addDays(-3).getTime());
         req.put('donorId', testAccount.get('fr_Id__c'));
         frTestUtil.createTestPost(req);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(req.get('id'));
         List<SObject> gc = Database.query(
             'SELECT Funraise_GT_Pledge__c ' +
@@ -861,7 +901,7 @@ public class frDonationTest {
         );
         System.assertEquals(pledge.Id, gc[0].get('Funraise_GT_Pledge__c'), 'The donation should have matched to a previously active unfulfilled pledge');
     }
-    
+
     //
     // syncEntity_oldDonation_doesNotMatchInactivePledge
     //
@@ -872,30 +912,30 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         //get a pledge that is inactive according to dates
         //but is unfulfilled in amount
         Pledge__c pledge = getTestPledge(testSupporter);
         pledge.Start_Date__c = Date.today().addDays(-5);
-        pledge.End_Date__c = Date.today().addDays(-1); 
+        pledge.End_Date__c = Date.today().addDays(-1);
         insert pledge;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('donation_cretime', DateTime.now().getTime());
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Opportunity opp = [SELECT Id, Funraise_Pledge__c FROM Opportunity WHERE fr_Id__c = :oppFrId];
         System.assertEquals(null, opp.Funraise_Pledge__c, 'The donation should not have matched to a previously active unfulfilled pledge');
     }
-    
+
     static testMethod void syncEntity_oldDonation_doesNotMatchInactivePledge_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
@@ -903,27 +943,27 @@ public class frDonationTest {
         createMapping('name', 'Name');
         createMapping('amount', 'OriginalAmount');
         insert frSetupController.getGiftTransactionDefaults();
-        
+
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonortest.getTestAccount(true);
         Pledge__c pledge = getTestPledgeAcc(testAccount);
         pledge.Start_Date__c = Date.today().addDays(-5);
         pledge.End_Date__c = Date.today().addDays(-1);
         insert pledge;
-        
+
         Map<String, Object> req = getTestRequest();
         req.put('donation_cretime', DateTime.now().getTime());
         req.put('donorId', '856');
         frTestUtil.createTestPost(req);
-        
+
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         // The original code didn't do an assertion for the else block
         // If you'd like to assert it's null, you can do so
     }
-    
+
     //
     // syncEntity_oppContactRoles_sameSupporter
     //
@@ -935,21 +975,21 @@ public class frDonationTest {
         createMapping('amount', 'amount');
         createMapping('donation_cretime', 'CloseDate');
         Contact testSupporter = frDonorTest.getTestContact();
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('opportunityContactMappingDisabled', false);
         request.put('donorId', testSupporter.fr_Id__c);
         request.put('fundraiserId', testSupporter.fr_Id__c);
         request.put('teamCaptainId', testSupporter.fr_Id__c);
         request.put('softCreditSupporterId', testSupporter.fr_Id__c);
-        
+
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
-        
+
         String oppFrId = String.valueOf(getTestRequest().get('id'));
         Set<String> funraiseRoles = new Set<String>{
             frDonation.OPP_ROLE_DONOR,
@@ -965,12 +1005,12 @@ public class frDonationTest {
         System.assertEquals(frDonation.OPP_ROLE_DONOR, opp.OpportunityContactRoles.get(0).role,
                             'The single opp contact role should be the donor role');
     }
-    
+
     static testMethod void syncEntity_setOpportunityStage_NPC() {
         if (!frUtil.hasNPCobjects()) {
             return;
         }
-        
+
         createMapping('name', 'Name');
         insert frSetupController.getGiftTransactionDefaults();
         Contact testContact = frDonorTest.getTestContact();
@@ -980,13 +1020,13 @@ public class frDonationTest {
         insert testCampaign;
         Subscription__c subscription = new Subscription__c(Name = 'Test Sub', fr_ID__c = '1234', Supporter__c = testContact.Id);
         insert subscription;
-        
+
         Map<String, Object> request = getTestRequest();
         request.put('subscriptionId', subscription.fr_ID__c);
         request.put('opportunityContactMappingDisabled', 'false');
         request.put('donorId', '856');
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         Sync_Attempt__c syncRecord = new Sync_Attempt__c(
             Request_Body__c = RestContext.request.requestBody.toString(),
@@ -999,10 +1039,10 @@ public class frDonationTest {
         frd.setOpportunityStage(new Opportunity(), 'Pending');
         frd.setOpportunityStage(new Opportunity(), 'Refunded');
         Test.stopTest();
-        
+
         frTestUtil.assertNoErrors();
     }
-    
+
     static testMethod void syncEntity_constantMapping_noOverwrite() {
         if (frUtil.hasNPCobjects()) {
             return; // skip in NPC org
@@ -1019,12 +1059,12 @@ public class frDonationTest {
             Type__c = frDonation.TYPE,
             Conflict_Resolution__c = frModel.MAPPING_NO_OVERWRITE
         );
-        
+
         Map<String, Object> request = getTestRequest();
         frTestUtil.createTestPost(request);
         Test.startTest();
         frWSDonationController.syncEntity();
-        
+
         Opportunity opportunity = [
             SELECT Id, Description
             FROM Opportunity
@@ -1032,14 +1072,14 @@ public class frDonationTest {
         ];
         //since this was a new record, there was no data that would have been overwritten so the constant value should be used
         System.assertEquals(constantValue, opportunity.Description, 'Constant mapping should populate the initial value');
-        
+
         opportunity.Description = updatedValue;
         update opportunity;
-        
+
         frTestUtil.createTestPost(request);
         frWSDonationController.syncEntity();
         Test.stopTest();
-        
+
         Opportunity updatedOpportunity = [
             SELECT Description
             FROM Opportunity
@@ -1048,7 +1088,7 @@ public class frDonationTest {
         System.assertEquals(updatedValue, updatedOpportunity.Description, 'Constant mapping with NO_OVERWRITE should not overwrite existing values');
         frTestUtil.assertNoErrors();
     }
-    
+
     //
     // Utility methods
     //
@@ -1060,7 +1100,7 @@ public class frDonationTest {
             Type__c = frDonation.TYPE
         );
     }
-    
+
     public static Map<String, Object> getTestRequest() {
         Map<String, Object> request = new Map<String, Object>();
         request.put('id', 2048);
@@ -1093,7 +1133,7 @@ public class frDonationTest {
         request.put('paymentMethodType', 'Cash');
         return request;
     }
-    
+
     public static Opportunity getTestOpp() {
         return new Opportunity(
             CloseDate = Date.today(),
@@ -1102,7 +1142,7 @@ public class frDonationTest {
             fr_Id__c = '19931107'
         );
     }
-    
+
     public static SObject getTestGT() {
         SObject o = Schema.getGlobalDescribe().get('gifttransaction').newSObject();
         o.put('Name', 'Unit Test Opportunity');
@@ -1113,14 +1153,14 @@ public class frDonationTest {
         o.put('PaymentMethod', 'Cash');
         return o;
     }
-    
+
     public static Pledge__c getTestPledge(Contact supporter) {
         return new Pledge__c(
             Supporter__c = supporter.Id,
             Pledge_Amount__c = 500
         );
     }
-    
+
     public static Pledge__c getTestPledgeAcc(Account supporter) {
         return new Pledge__c(
             Supporter__c = (String) supporter.get('PersonContactId'),

--- a/src/classes/frModel.cls
+++ b/src/classes/frModel.cls
@@ -3,52 +3,52 @@ public with sharing abstract class frModel {
     public static final String MAPPING_NO_OVERWRITE = 'do_not_overwrite';
     public static final String MAPPING_OVERWRITE_NON_NULL = 'overwrite_non_null';
     public static final String MAPPING_OVERWRITE_RECENT = 'overwrite_more_recent';
-    
+
     protected Sync_Attempt__c syncRecord;
     protected Map<String, Object> requestBody;
     protected Boolean createLogRecord = false;
-    
+
     public frModel(Sync_Attempt__c attempt) {
         this.syncRecord = attempt;
         createLogRecord = attempt.Attempts__c >= frSyncRequestHandler.MAX_ATTEMPTS;
     }
-    
+
     protected Map<String, Object> getRequestBody() {
         if (requestBody == null) {
             requestBody = (Map<String, Object>)JSON.deserializeUntyped(syncRecord.Request_Body__c);
         }
         return requestBody;
     }
-    
+
     protected virtual String getFunraiseId() {
         return String.valueOf(getRequestBody().get('id'));
     }
-    
+
     protected virtual String getSalesforceId() {
         return null;
     }
-    
+
     protected virtual Boolean requireObjectDeletePermission() {
         return false;
     }
-    
+
     protected virtual String getUpdtimeJsonKey() {
         return 'updtime';
     }
-    
+
     private Datetime getUpdtime() {
         if(getRequestBody().containsKey(getUpdtimeJsonKey())) {
             return Datetime.newInstance((Long)getRequestBody().get(getUpdtimeJsonKey()));
         }
         return null;
     }
-    
+
     protected abstract Set<Schema.SObjectField> getFields();
     protected abstract Set<Schema.SObjectType> getObjects();
     protected abstract frUtil.Entity getFrType();
-    
+
     public boolean checkPermissions() {
-        Boolean success = true;        
+        Boolean success = true;
         String error = '';
         for(Schema.SObjectType objTypeRef : getObjects()) {
             DescribeSObjectResult objType = objTypeRef.getDescribe();
@@ -69,13 +69,17 @@ public with sharing abstract class frModel {
         }
         return success;
     }
-    
-    
+
+
     protected virtual List<frMapping__c> getMappings() {
         return new List<frMapping__c>();
     }
-    
+
     protected void applyMappings(SObject record, Map<String, Object> request) {
+        applyMappings(record, request, 'fr_ID__c');
+    }
+
+    protected void applyMappings(SObject record, Map<String, Object> request, String funraiseIdFieldName) {
         String sObjectName = record.getSObjectType().getDescribe().getName();
         Map<String, Schema.SObjectField> fields = frSchemaUtil.getFields(sObjectName);
         //a single funraise field might flow into multiple salesforce fields
@@ -96,7 +100,7 @@ public with sharing abstract class frModel {
                 mappings.add(mapping);
                 frFieldToMappings.put(mapping.fr_Name__c, mappings);
             }
-            
+
             if(mapping.Conflict_Resolution__c == MAPPING_NO_OVERWRITE) {
                 //We need to know the existing values of these fields
                 //if null, we can sync the incoming data.  Otherwise, we don't overwrite
@@ -105,34 +109,34 @@ public with sharing abstract class frModel {
             if(!needLastModifiedDate && mapping.Conflict_Resolution__c == MAPPING_OVERWRITE_RECENT) {
                 needLastModifiedDate = true;
             }
-        }        
-        if(needLastModifiedDate) {
-            fieldsToQueryFor.add('LastModifiedDate');    
         }
-        
+        if(needLastModifiedDate) {
+            fieldsToQueryFor.add('LastModifiedDate');
+        }
+
         String funraiseId = getFunraiseId();
         String salesforceId = getSalesforceId();
         SObject queriedFieldsRecord = null;
         if(!fieldsToQueryFor.isEmpty()) {
-            String query = 'SELECT ' + String.join(new List<String>(fieldsToQueryFor), ',') 
+            String query = 'SELECT ' + String.join(new List<String>(fieldsToQueryFor), ',')
                 + ' FROM ' + sObjectName + ' WHERE ';
             if(getSalesforceId() != null) {
                 query += 'Id = :salesforceId';
             } else {
-                query += 'fr_Id__c = :funraiseId';
+                query += funraiseIdFieldName + ' = :funraiseId';
             }
             List<SObject> results = Database.query(query);
             if(results.size() > 0) {
                 queriedFieldsRecord = results.get(0);
-            }    
+            }
         }
-        
+
         Boolean isMoreRecent = queriedFieldsRecord == null; //if we didn't get a queriedFieldsRecord returned, all fields from Funraise are more recent
         if(needLastModifiedDate && queriedFieldsRecord != null) {
             Datetime sfRecordUpdtime = (Datetime)queriedFieldsRecord.get('LastModifiedDate');
             isMoreRecent = getUpdtime() != null ? getUpdtime() > sfRecordUpdtime : false;
         }
-        
+
         for(String fieldName : frFieldToMappings.keySet()) {
             if(request.containsKey(fieldName)) {
                 for(frMapping__c mapping : frFieldToMappings.get(fieldName)) {
@@ -140,7 +144,7 @@ public with sharing abstract class frModel {
                     Object incomingValue = request.get(fieldName);
                     Boolean write = shouldWriteMapping(mapping, incomingValue, queriedFieldsRecord, isMoreRecent, field, sObjectName);
                     if(write) {
-                        write(record, field, mapping.sf_Name__c, incomingValue, funraiseId);    
+                        write(record, field, mapping.sf_Name__c, incomingValue, funraiseId);
                     }
                 }
             }
@@ -151,9 +155,11 @@ public with sharing abstract class frModel {
             if(write) {
                 write(record, field, constantMapping.sf_Name__c, constantMapping.Constant_Value__c, funraiseId);
             }        }
-        record.put('fr_ID__c', funraiseId);
+        if(String.isNotBlank(funraiseIdFieldName)) {
+            record.put(funraiseIdFieldName, funraiseId);
+        }
     }
-    
+
     private static Boolean shouldWriteMapping(frMapping__c mapping, Object incomingValue, SObject queriedFieldsRecord, Boolean isMoreRecent, Schema.SObjectField field, String sObjectName) {
         Boolean write = false;
         if(String.isBlank(mapping.Conflict_Resolution__c) || mapping.Conflict_Resolution__c == MAPPING_OVERWRITE) {
@@ -171,7 +177,7 @@ public with sharing abstract class frModel {
         }
         return write;
     }
-    
+
     public static void write(SObject record, Schema.SObjectField field, String fieldName, Object value, String funraiseId) {
         try {
             if (fieldName.toLowerCase() == 'id') {
@@ -186,12 +192,12 @@ public with sharing abstract class frModel {
                     List<Object> localDate = (List<Object>)value;
                     if(localDate.size() > 3) {
                         DateTime sfLocalDateTime = convertFromLocalDateTime(localDate);
-                        record.put(field, sfLocalDateTime);                        
+                        record.put(field, sfLocalDateTime);
                     } else if (localDate.size() == 3) {
                         Date sfLocalDate = convertFromLocalDate(localDate);
-                        record.put(field, sfLocalDate);                        
+                        record.put(field, sfLocalDate);
                     }
-                    
+
                 } else {
                     record.put(field, DateTime.newInstance((Long)value).date());
                 }
@@ -211,7 +217,7 @@ public with sharing abstract class frModel {
             write(record, field, value, funraiseId);
         }
     }
-    
+
     private static void write(SObject record, Schema.SObjectField field, Object value, String funraiseId) {
         try {
             if(value instanceof String) {
@@ -229,7 +235,7 @@ public with sharing abstract class frModel {
             }
         }
     }
-    
+
     public static DateTime convertFromLocalDateTime(List<Object> localDateTime) {
         return DateTime.newInstance(
             (Integer)localDateTime.get(0), //year
@@ -240,7 +246,7 @@ public with sharing abstract class frModel {
             0           //second
         );
     }
-    
+
     public static Date convertFromLocalDate(List<Object> localDate) {
         return Date.newInstance(
             (Integer)localDate.get(0), //year

--- a/src/classes/frSetupController.cls
+++ b/src/classes/frSetupController.cls
@@ -11,13 +11,19 @@ public with sharing class frSetupController {
 		}
 		private set;
 	}
+	public static String NPSP_RECURRING_DONATION_TYPE {
+		get {
+			return frSubscription.NPSP_RECURRING_DONATION_TYPE;
+		}
+		private set;
+	}
 	public static String DONOR_TYPE {
 		get {
 			return frDonor.TYPE;
 		}
 		private set;
 	}
-    
+
     public static Set<String> RESTRICTED_DONOR_FIELDS {
         get {
             if(RESTRICTED_DONOR_FIELDS == null) {
@@ -29,12 +35,12 @@ public with sharing class frSetupController {
         }
         private set;
     }
-    
+
     public static Set<String> RESTRICTED_DONATION_FIELDS {
         get {
             if(RESTRICTED_DONATION_FIELDS == null) {
                 RESTRICTED_DONATION_FIELDS = new Set<String>{
-                    'funraise__fr_ID__c', 
+                    'funraise__fr_ID__c',
                     'funraise__fr_Donor__c'
                 };
             }
@@ -42,7 +48,21 @@ public with sharing class frSetupController {
         }
         private set;
     }
-    
+
+    public static Set<String> RESTRICTED_NPSP_RECURRING_DONATION_FIELDS {
+        get {
+            if(RESTRICTED_NPSP_RECURRING_DONATION_FIELDS == null) {
+                RESTRICTED_NPSP_RECURRING_DONATION_FIELDS = new Set<String>{
+                    frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME.toLowerCase(),
+                    frUtil.NPSP_RECURRING_DONATION_CONTACT_FIELD_NAME.toLowerCase(),
+                    frUtil.NPSP_RECURRING_DONATION_ACCOUNT_FIELD_NAME.toLowerCase()
+                };
+            }
+            return RESTRICTED_NPSP_RECURRING_DONATION_FIELDS;
+        }
+        private set;
+    }
+
     public static String MAPPING_OVERWRITE {
         get {
             return frModel.MAPPING_OVERWRITE;
@@ -80,9 +100,17 @@ public with sharing class frSetupController {
 	public List<SelectOption> giftCommitmentFROptions {get; set;}
 	public List<frMapping__c> giftCommitmentMappings {get; set;}
 
+	public List<SelectOption> npspRecurringDonationSFOptions {get; set;}
+	public List<SelectOption> npspRecurringDonationFROptions {get; set;}
+	public List<frMapping__c> npspRecurringDonationMappings {get; set;}
+
+	public List<SelectOption> subscriptionTargetOptions {get; set;}
+	public String subscriptionTarget {get; set;}
+
 	public Boolean personAccountsEnabled { get; set; }
 	public Boolean isNonProfitOrg { get; set; }
-	
+	public Boolean npspRecurringDonationsEnabled { get; set; }
+
 	public frSetupController() {
 		SelectOption noneOption = new SelectOption('', '--None--');
 		donationSFOptions = new List<SelectOption>();
@@ -97,8 +125,15 @@ public with sharing class frSetupController {
 		giftCommitmentSFOptions.add(noneOption);
 		giftCommitmentFROptions = new List<SelectOption>();
 		giftCommitmentFROptions.add(noneOption);
+		npspRecurringDonationSFOptions = new List<SelectOption>();
+		npspRecurringDonationSFOptions.add(noneOption);
+		npspRecurringDonationFROptions = new List<SelectOption>();
+		npspRecurringDonationFROptions.add(noneOption);
+		subscriptionTargetOptions = new List<SelectOption>();
+		subscriptionTarget = frUtil.getSubscriptionTarget();
 		personAccountsEnabled = false;
 		isNonProfitOrg = false;
+		npspRecurringDonationsEnabled = false;
 
 		//Check for personaccount field on account
         SObjectType accountType = Account.SObjectType;
@@ -141,6 +176,7 @@ public with sharing class frSetupController {
 		}
 
 		if (!frUtil.hasNPCobjects()) {
+			initializeSubscriptionTargetOptions();
 			Map<String, Schema.SObjectField> oppFields = Opportunity.sObjectType.getDescribe().fields.getMap();
 			for(String fieldName : oppFields.keySet()) {
 				if(RESTRICTED_DONATION_FIELDS.contains(fieldName)) continue; //skip any fields that are part of the managed package
@@ -150,6 +186,21 @@ public with sharing class frSetupController {
 				}
 			}
 			donationSFOptions.sort();
+		}
+		if (!frUtil.hasNPCobjects() && frUtil.hasNPSPRecurringDonations()) {
+			npspRecurringDonationsEnabled = true;
+			Map<String, Schema.SObjectField> recurringDonationFields = frUtil.getFields(frUtil.NPSP_RECURRING_DONATION_OBJ_NAME);
+			for(String fieldName : recurringDonationFields.keySet()) {
+				if(RESTRICTED_NPSP_RECURRING_DONATION_FIELDS.contains(fieldName.toLowerCase())) continue;
+				Schema.DescribeFieldResult describe = recurringDonationFields.get(fieldName).getDescribe();
+				if(describe.isUpdateable()) {
+					npspRecurringDonationSFOptions.add(new SelectOption(fieldName, describe.getLabel()));
+				}
+			}
+			npspRecurringDonationSFOptions.sort();
+			for(frField__mdt field : [SELECT DeveloperName, MasterLabel FROM frField__mdt WHERE Type__c = :GIFT_COMMITMENT_TYPE ORDER BY MasterLabel]) {
+				npspRecurringDonationFROptions.add(new SelectOption(field.DeveloperName.removeEnd('_GC'), field.MasterLabel));
+			}
 		}
 		for(frField__mdt field : [SELECT DeveloperName, MasterLabel FROM frField__mdt WHERE Type__c = 'Donation' ORDER BY MasterLabel]) {
 			donationFROptions.add(new SelectOption(field.DeveloperName, field.MasterLabel));
@@ -166,14 +217,25 @@ public with sharing class frSetupController {
 			}
 			donorSFOptions.sort();
 		}
-		
+
 		for(frField__mdt field : [SELECT DeveloperName, MasterLabel FROM frField__mdt WHERE Type__c = 'Donor' ORDER BY MasterLabel]) {
 			donorFROptions.add(new SelectOption(field.DeveloperName, field.MasterLabel));
 		}
-        
+
 		donationMappings = frDonation.mappings;
 		donorMappings = frDonor.mappings;
 		giftCommitmentMappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :GIFT_COMMITMENT_TYPE ORDER BY CreatedDate];
+		npspRecurringDonationMappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :NPSP_RECURRING_DONATION_TYPE ORDER BY CreatedDate];
+	}
+
+	private void initializeSubscriptionTargetOptions() {
+		subscriptionTargetOptions.add(new SelectOption(frUtil.SUBSCRIPTION_TARGET_FUNRAISE, 'Funraise Subscription'));
+		if(frUtil.hasNPSPRecurringDonations()) {
+			subscriptionTargetOptions.add(new SelectOption(frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION, 'NPSP Recurring Donation'));
+		}
+		if(frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION.equals(subscriptionTarget) && !frUtil.hasNPSPRecurringDonations()) {
+			subscriptionTarget = frUtil.SUBSCRIPTION_TARGET_FUNRAISE;
+		}
 	}
 
 	public void addMapping() {
@@ -181,8 +243,11 @@ public with sharing class frSetupController {
 		if(String.isBlank(type)) {
 			return;
 		}
-		if(GIFT_COMMITMENT_TYPE.equals(type)) {			
+		if(GIFT_COMMITMENT_TYPE.equals(type)) {
 			giftCommitmentMappings.add(new frMapping__c(Type__c = GIFT_COMMITMENT_TYPE));
+		}
+		else if(NPSP_RECURRING_DONATION_TYPE.equals(type)) {
+			npspRecurringDonationMappings.add(new frMapping__c(Type__c = NPSP_RECURRING_DONATION_TYPE));
 		}
 		else if(DONATION_TYPE.equals(type)) {
 			donationMappings.add(new frMapping__c(Type__c = DONATION_TYPE));
@@ -207,6 +272,9 @@ public with sharing class frSetupController {
 		if (GIFT_COMMITMENT_TYPE.equals(type)) {
 			mappings = giftCommitmentMappings;
 		}
+		if (NPSP_RECURRING_DONATION_TYPE.equals(type)) {
+			mappings = npspRecurringDonationMappings;
+		}
 		for(Integer i = 0; i < mappings.size(); i++) {
 			frMapping__c mapping = mappings.get(i);
 			if(recordId.equals(mapping.id)) {
@@ -217,23 +285,27 @@ public with sharing class frSetupController {
 			}
 		}
 	}
-    
+
 	public void save() {
+		saveSubscriptionTarget();
+
         if (!Schema.sObjectType.frMapping__c.fields.Name.isUpdateable() ||
            !Schema.sObjectType.frMapping__c.fields.Name.isCreateable()) {
             return;
         }
-        
+
 		Integer customSettingNameLength = frMapping__c.Name.getDescribe().getLength();
 		List<frMapping__c> upsertList = new List<frMapping__c>();
 		List<frMapping__c> allMappings = new List<frMapping__c>(donationMappings);
 		allMappings.addAll(donorMappings);
 		allMappings.addAll(giftCommitmentMappings);
+		allMappings.addAll(npspRecurringDonationMappings);
 		for(frMapping__c mapping : allMappings) {
 			if(String.isNotBlank(mapping.sf_Name__c)) {
 				if(mapping.Type__c == DONATION_TYPE) mapping.Name = 'o.' + mapping.sf_Name__c;
 				if(mapping.Type__c == DONOR_TYPE) mapping.Name = 'c.' + mapping.sf_Name__c;
 				if(mapping.Type__c == GIFT_COMMITMENT_TYPE) mapping.Name = 's.' + mapping.sf_Name__c;
+				if(mapping.Type__c == NPSP_RECURRING_DONATION_TYPE) mapping.Name = 'npsp_rd.' + mapping.sf_Name__c;
 				if(mapping.Name.length() > customSettingNameLength) {
 					mapping.Name = mapping.Name.subString(0, customSettingNameLength);
 				}
@@ -248,6 +320,36 @@ public with sharing class frSetupController {
 		}
 	}
 
+	private void saveSubscriptionTarget() {
+		if(frUtil.hasNPCobjects() || String.isBlank(subscriptionTarget)) {
+			return;
+		}
+		if(!frUtil.SUBSCRIPTION_TARGET_FUNRAISE.equals(subscriptionTarget)
+			&& !frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION.equals(subscriptionTarget)) {
+			return;
+		}
+		if(frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION.equals(subscriptionTarget)
+			&& !frUtil.hasNPSPRecurringDonations()) {
+			subscriptionTarget = frUtil.SUBSCRIPTION_TARGET_FUNRAISE;
+		}
+		try {
+			List<frSetting__c> settings = [
+				SELECT Id, Value__c
+				FROM frSetting__c
+				WHERE Name = :frUtil.SETTING_SUBSCRIPTION_TARGET
+				LIMIT 1
+			];
+			frSetting__c setting = settings.isEmpty()
+				? new frSetting__c(Name = frUtil.SETTING_SUBSCRIPTION_TARGET)
+				: settings.get(0);
+			setting.Value__c = subscriptionTarget;
+			upsert setting;
+			addConfirm('Settings saved successfully');
+		} catch (Exception ex) {
+			addError('Settings not saved. ' + ex.getMessage());
+		}
+	}
+
 	public PageReference cancel() {
 		PageReference redirect = Page.frSetup;
         redirect.setRedirect(true);
@@ -259,7 +361,7 @@ public with sharing class frSetupController {
 	}
 
 	private static void addError(String message) {
-		ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, message));	
+		ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, message));
 	}
 
 	public void defaults() {
@@ -271,7 +373,8 @@ public with sharing class frSetupController {
 		if(!frUtil.hasNPCobjects()) {
 			defaults = getDonorDefaults();
 			defaults.addAll(getDonationDefaults());
-		} 
+			defaults.addAll(getNPSPRecurringDonationDefaults());
+		}
 		else {
 			defaults = getGiftTransactionDefaults();
 			defaults.addAll(getPersonAccountDefaults());
@@ -280,6 +383,7 @@ public with sharing class frSetupController {
 		addConfirm('All Defaults Applied');
 		donationMappings = frDonation.mappings;
 		donorMappings = frDonor.mappings;
+		npspRecurringDonationMappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :NPSP_RECURRING_DONATION_TYPE ORDER BY CreatedDate];
 	}
 
 	public void donorDefaults() {
@@ -302,6 +406,17 @@ public with sharing class frSetupController {
 		insert defaults;
 		addConfirm('Donation Defaults Applied');
 		donationMappings = frDonation.mappings;
+	}
+
+	public void npspRecurringDonationDefaults() {
+		if(!checkCD()) {
+			return;
+		}
+		delete [SELECT Id FROM frMapping__c WHERE Type__c = :NPSP_RECURRING_DONATION_TYPE];
+		List<frMapping__c> defaults = getNPSPRecurringDonationDefaults();
+		insert defaults;
+		addConfirm('NPSP Recurring Donation Defaults Applied');
+		npspRecurringDonationMappings = [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :NPSP_RECURRING_DONATION_TYPE ORDER BY CreatedDate];
 	}
 
 	private Boolean checkCD() {
@@ -360,5 +475,23 @@ public with sharing class frSetupController {
 			new frMapping__c(Name = 'Postal Code Default', fr_Name__c = 'postalCode', sf_Name__c = 'personmailingpostalcode', Type__c = DONOR_TYPE),
 			new frMapping__c(Name = 'Country Default', fr_Name__c = 'country', sf_Name__c = 'personmailingcountry', Type__c = DONOR_TYPE)
 		};
+	}
+
+	@testVisible
+	private static List<frMapping__c> getNPSPRecurringDonationDefaults() {
+		List<frMapping__c> defaults = new List<frMapping__c>();
+		addNPSPRecurringDonationDefault(defaults, 'Subscription Name Default', 'name', 'Name');
+		addNPSPRecurringDonationDefault(defaults, 'Amount Default', 'amount', 'npe03__Amount__c');
+		addNPSPRecurringDonationDefault(defaults, 'Date Established Default', 'nextPaymentDate', 'npe03__Date_Established__c');
+		addNPSPRecurringDonationDefault(defaults, 'Next Payment Date Default', 'nextPaymentDate', 'npe03__Next_Payment_Date__c');
+		addNPSPRecurringDonationDefault(defaults, 'Start Date Default', 'nextPaymentDate', 'npe03__StartDate__c');
+		return defaults;
+	}
+
+	private static void addNPSPRecurringDonationDefault(List<frMapping__c> defaults, String name, String frName, String sfName) {
+		Schema.SObjectField field = frUtil.getField(frUtil.NPSP_RECURRING_DONATION_OBJ_NAME, sfName);
+		if(frUtil.hasNPSPRecurringDonations() && field != null && field.getDescribe().isCreateable()) {
+			defaults.add(new frMapping__c(Name = name, fr_Name__c = frName, sf_Name__c = sfName, Type__c = NPSP_RECURRING_DONATION_TYPE));
+		}
 	}
 }

--- a/src/classes/frSetupControllerTest.cls
+++ b/src/classes/frSetupControllerTest.cls
@@ -47,6 +47,42 @@ public class frSetupControllerTest {
 	}
 
 	@IsTest
+	static void test_subscriptionTargetDefaultsToFunraise() {
+		if (frUtil.hasNPCobjects()) return;
+
+		Test.startTest();
+		frSetupController controller = new frSetupController();
+		Test.stopTest();
+
+		System.assertEquals(frUtil.SUBSCRIPTION_TARGET_FUNRAISE, controller.subscriptionTarget, 'The default subscription target should remain the Funraise Subscription object');
+		assertOptionPresent(controller.subscriptionTargetOptions, frUtil.SUBSCRIPTION_TARGET_FUNRAISE);
+		if(frUtil.hasNPSPRecurringDonations()) {
+			assertOptionPresent(controller.subscriptionTargetOptions, frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION);
+		} else {
+			assertOptionNotPresent(controller.subscriptionTargetOptions, frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION);
+		}
+	}
+
+	@IsTest
+	static void test_saveSubscriptionTarget() {
+		if (frUtil.hasNPCobjects()) return;
+
+		frSetupController controller = new frSetupController();
+		controller.subscriptionTarget = frUtil.SUBSCRIPTION_TARGET_FUNRAISE;
+
+		Test.startTest();
+		controller.save();
+		Test.stopTest();
+
+		frSetting__c setting = [
+			SELECT Value__c
+			FROM frSetting__c
+			WHERE Name = :frUtil.SETTING_SUBSCRIPTION_TARGET
+		];
+		System.assertEquals(frUtil.SUBSCRIPTION_TARGET_FUNRAISE, setting.Value__c, 'The selected subscription target should be saved');
+	}
+
+	@IsTest
 	static void test_addMapping() {
 		Test.startTest();
 		frSetupController controller = new frSetupController();
@@ -72,6 +108,26 @@ public class frSetupControllerTest {
 		System.assertEquals(2, [SELECT COUNT() FROM frMapping__c], 'Only one mapping was added, so only one mapping should exist');
 		System.assertEquals(frSetupController.DONATION_TYPE, donationMapping.Type__c, 'The mapping added first should have a donation type');
 		System.assertEquals(frSetupController.DONOR_TYPE, donorMapping.Type__c, 'The mapping added second should have a donor type');
+	}
+
+	@IsTest
+	static void test_addMapping_NPSPRecurringDonation() {
+		if (!frUtil.hasNPSPRecurringDonations() || frUtil.hasNPCobjects()) return;
+
+		Test.startTest();
+		frSetupController controller = new frSetupController();
+		ApexPages.currentPage().getParameters().put('type', frSetupController.NPSP_RECURRING_DONATION_TYPE);
+		controller.addMapping();
+		Integer actualMappingCountAfterAdd = controller.npspRecurringDonationMappings.size();
+		frMapping__c mapping = controller.npspRecurringDonationMappings.get(0);
+		mapping.fr_Name__c = 'amount';
+		mapping.sf_Name__c = 'npe03__Amount__c';
+		controller.save();
+		Test.stopTest();
+
+		System.assertEquals(1, actualMappingCountAfterAdd, 'Only one NPSP Recurring Donation mapping should have been added');
+		System.assertEquals(1, [SELECT COUNT() FROM frMapping__c WHERE Type__c = :frSetupController.NPSP_RECURRING_DONATION_TYPE]);
+		System.assertEquals(frSetupController.NPSP_RECURRING_DONATION_TYPE, mapping.Type__c, 'The mapping should have the NPSP Recurring Donation type');
 	}
 
 	@IsTest
@@ -211,6 +267,40 @@ public class frSetupControllerTest {
 		assertMappingsEqual(frSetupController.getDonationDefaults(), actualDonationMappings);
 	}
 
+	@IsTest
+	static void test_npspRecurringDonationMappingsUnavailableWithoutNPSP() {
+		if (frUtil.hasNPSPRecurringDonations() || frUtil.hasNPCobjects()) return;
+
+		Test.startTest();
+		frSetupController controller = new frSetupController();
+		Test.stopTest();
+
+		System.assertEquals(false, controller.npspRecurringDonationsEnabled, 'The NPSP mapping section should not render without NPSP Recurring Donations');
+		System.assertEquals(frUtil.SUBSCRIPTION_TARGET_FUNRAISE, controller.subscriptionTarget, 'The setup page should fall back to the Funraise Subscription target');
+		assertOptionNotPresent(controller.subscriptionTargetOptions, frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION);
+		System.assertEquals(0, controller.npspRecurringDonationMappings.size(), 'There should not be NPSP mappings in non-NPSP orgs');
+		System.assertEquals(0, frSetupController.getNPSPRecurringDonationDefaults().size(), 'NPSP defaults should not be generated without the NPSP target object');
+	}
+
+	@IsTest
+	static void test_defaults_NPSPRecurringDonationOnly() {
+		if (!frUtil.hasNPSPRecurringDonations() || frUtil.hasNPCobjects()) return;
+
+		insert new frMapping__c(Type__c = frSetupController.NPSP_RECURRING_DONATION_TYPE, fr_Name__c = 'testfr', sf_Name__c = 'testsf', Name = 'Test Mapping');
+		Integer beforeTestMappingCount = [SELECT COUNT() FROM frMapping__c];
+
+		frSetupController controller = new frSetupController();
+		Test.startTest();
+		controller.npspRecurringDonationDefaults();
+		Integer afterDefaultMappingCount = [SELECT COUNT() FROM frMapping__c WHERE fr_Name__c = 'testfr'];
+		List<frMapping__c> actualMappings = [SELECT Name FROM frMapping__c WHERE Type__c = :frSetupController.NPSP_RECURRING_DONATION_TYPE];
+		Test.stopTest();
+
+		System.assertEquals(1, beforeTestMappingCount, 'There should have been 1 mapping record before the test started');
+		System.assertEquals(0, afterDefaultMappingCount, 'There should not be test data mappings after using NPSP defaults');
+		assertMappingsEqual(frSetupController.getNPSPRecurringDonationDefaults(), actualMappings);
+	}
+
 	private static void assertMappingsEqual(List<frMapping__c> expected, List<frMapping__c> actual) {
 		Set<String> expectedMappingNames = new Set<String>();
 		for(frMapping__c mapping : expected) {
@@ -231,5 +321,22 @@ public class frSetupControllerTest {
 		//remove empty string from controller values since we don't care about the --None-- option
 		actualValues.remove('');
 		System.assertEquals(expectedValues, actualValues, 'The fields in the metadata setting and the fields available in the controller do not match');
+	}
+
+	private static void assertOptionPresent(List<SelectOption> options, String expectedValue) {
+		System.assertEquals(true, optionValuesContain(options, expectedValue), 'Expected option was not present: ' + expectedValue);
+	}
+
+	private static void assertOptionNotPresent(List<SelectOption> options, String expectedValue) {
+		System.assertEquals(false, optionValuesContain(options, expectedValue), 'Unexpected option was present: ' + expectedValue);
+	}
+
+	private static Boolean optionValuesContain(List<SelectOption> options, String expectedValue) {
+		for(SelectOption option : options) {
+			if(expectedValue.equals(option.getValue())) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/classes/frSubscription.cls
+++ b/src/classes/frSubscription.cls
@@ -39,13 +39,27 @@
 */
 
 public class frSubscription extends frModel implements frSyncable {
-    public static final Map<String, Schema.SObjectField> fields = 
+    public static final String NPSP_RECURRING_DONATION_TYPE = 'NPSP Recurring Donation';
+    private static final String NPSP_RD_AMOUNT_FIELD_NAME = 'npe03__Amount__c';
+    private static final String NPSP_RD_DATE_ESTABLISHED_FIELD_NAME = 'npe03__Date_Established__c';
+    private static final String NPSP_RD_DAY_OF_MONTH_FIELD_NAME = 'npe03__Day_of_Month__c';
+    private static final String NPSP_RD_INSTALLMENT_FREQUENCY_FIELD_NAME = 'npe03__InstallmentFrequency__c';
+    private static final String NPSP_RD_INSTALLMENT_PERIOD_FIELD_NAME = 'npe03__Installment_Period__c';
+    private static final String NPSP_RD_NEXT_PAYMENT_DATE_FIELD_NAME = 'npe03__Next_Payment_Date__c';
+    private static final String NPSP_RD_OPEN_ENDED_STATUS_FIELD_NAME = 'npe03__Open_Ended_Status__c';
+    private static final String NPSP_RD_PAYMENT_METHOD_FIELD_NAME = 'npe03__PaymentMethod__c';
+    private static final String NPSP_RD_RECURRING_TYPE_FIELD_NAME = 'npe03__RecurringType__c';
+    private static final String NPSP_RD_SCHEDULE_TYPE_FIELD_NAME = 'npe03__Schedule_Type__c';
+    private static final String NPSP_RD_START_DATE_FIELD_NAME = 'npe03__StartDate__c';
+    private static final String NPSP_RD_STATUS_FIELD_NAME = 'npe03__Status__c';
+
+    public static final Map<String, Schema.SObjectField> fields =
         frSchemaUtil.getFields(Subscription__c.getSObjectType().getDescribe().getName());
-        
+
     public frSubscription(Sync_Attempt__c syncRecord){
         super(syncRecord);
     }
-    
+
     public Boolean sync() {
         Boolean result = false;
         Map<String, Object> request = getRequestBody();
@@ -56,24 +70,30 @@ public class frSubscription extends frModel implements frSyncable {
         }
         return result;
     }
-    
+
     private Boolean deleteSubscription(String funraiseId) {
         Boolean result = false;
         try {
-            if(!frUtil.hasNPCobjects()) {
-                delete [SELECT id FROM Subscription__c WHERE fr_ID__c = :funraiseId];
-                result = true;
-            }
-            else {
+            if(frUtil.hasNPCobjects()) {
                 delete Database.query('SELECT Id FROM GiftCommitment WHERE fr_ID__c = :funraiseId');
                 result = true;
             }
-        } catch (DMLException e) {
+            else if(frUtil.usesNPSPRecurringDonations()) {
+                String query = 'SELECT Id FROM ' + frUtil.NPSP_RECURRING_DONATION_OBJ_NAME
+                    + ' WHERE ' + frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME + ' = :funraiseId';
+                delete Database.query(query);
+                result = true;
+            }
+            else {
+                delete [SELECT id FROM Subscription__c WHERE fr_ID__c = :funraiseId];
+                result = true;
+            }
+        } catch (Exception e) {
             if(createLogRecord) frUtil.logException(getFrType(), funraiseId, e);
         }
         return result;
     }
-    
+
     private Boolean create(Map<String, Object> request) {
         Boolean result = false;
         String funraiseId = getFunraiseId();
@@ -82,13 +102,13 @@ public class frSubscription extends frModel implements frSyncable {
         String goalId = String.valueOf(request.get('campaignGoalId'));
         String strPledgeAmount = String.valueOf(request.get('pledgeAmount'));
         Decimal pledgeAmount = String.isNotBlank(strPledgeAmount) ? Decimal.valueOf(strPledgeAmount) : null;
-        List<Contact> contacts = [SELECT Id from Contact WHERE fr_Id__c = :funraiseSupporterId];
+        List<Contact> contacts = [SELECT Id, AccountId from Contact WHERE fr_Id__c = :funraiseSupporterId];
         List<Account> accounts = new List<Account>();
         if (frUtil.hasNPCobjects()) {
             accounts = Database.query('SELECT Id, PersonContactId FROM Account WHERE fr_ID__c = :funraiseSupporterId');
         }
         if(contacts.isEmpty() && accounts.isEmpty()) {
-            if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId, 
+            if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId,
                                         frUtil.Entity.SUPPORTER, funraiseSupporterId);
             return result;
         }
@@ -98,13 +118,13 @@ public class frSubscription extends frModel implements frSyncable {
             List<SObject> gcList = Database.query('SELECT Id, Name FROM GiftCommitment WHERE fr_ID__c = :funraiseId');
             if(gcList.isEmpty()) {
                 gc = Schema.getGlobalDescribe().get('giftcommitment').newSObject();
-            } 
+            }
             else {
                 gc = gcList.get(0);
             }
             gc.put('fr_ID__c', funraiseId);
             gc.put('Name', frUtil.truncateToFieldLength(
-                Schema.getGlobalDescribe().get('GiftCommitment').getDescribe().fields.getMap().get('Name').getDescribe(), 
+                Schema.getGlobalDescribe().get('GiftCommitment').getDescribe().fields.getMap().get('Name').getDescribe(),
                 String.valueOf(request.get('name'))
             ));
             gc.put('DonorId', accounts.get(0).Id);
@@ -115,7 +135,7 @@ public class frSubscription extends frModel implements frSyncable {
                 if (campaigns.size() > 0) {
                     gc.put('CampaignId', campaigns.get(0).Id);
                 } else {
-                    if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId, 
+                    if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId,
                                                 frUtil.Entity.CAMPAIGN, goalId);
                 }
             }
@@ -128,14 +148,22 @@ public class frSubscription extends frModel implements frSyncable {
                 if(createLogRecord) frUtil.logException(getFrType(), funraiseId, ex);
                 return result;
             }
-            
+
             if(pledgeAmount != null) {
                 frPledge.create(gc, pledgeAmount);
             }
             return result;
-        } 
+        }
+        else if(frUtil.usesNPSPRecurringDonations()) {
+            if(contacts.isEmpty()) {
+                if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId,
+                                            frUtil.Entity.SUPPORTER, funraiseSupporterId);
+                return result;
+            }
+            return createNPSPRecurringDonation(request, contacts.get(0));
+        }
         else if(contacts.isEmpty()) {
-            if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId, 
+            if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId,
                                         frUtil.Entity.SUPPORTER, funraiseSupporterId);
             return result;
         }
@@ -143,9 +171,9 @@ public class frSubscription extends frModel implements frSyncable {
             subscription = new Subscription__c(
                 fr_ID__c = funraiseId,
                 Name = frUtil.truncateToFieldLength(
-                    Subscription__c.Name.getDescribe(), 
+                    Subscription__c.Name.getDescribe(),
                     String.valueOf(request.get('name'))
-                ), 
+                ),
                 Supporter__c = contacts.get(0).Id
             );
         }
@@ -155,11 +183,11 @@ public class frSubscription extends frModel implements frSyncable {
             if (campaigns.size() > 0) {
                 subscription.Campaign_Goal__c = campaigns.get(0).Id;
             } else {
-                if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId, 
+                if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId,
                                             frUtil.Entity.CAMPAIGN, goalId);
             }
         }
-        
+
     //transform other request fields into SF custom fields, these are not applicable
         request.remove('id');
         request.remove('name');
@@ -167,7 +195,7 @@ public class frSubscription extends frModel implements frSyncable {
         request.remove('campaignGoalId');
         request.remove('deleted');
         request.remove('pledgeAmount');
-        
+
         String regex = '([a-z])([A-Z]+)';
         String replacement = '$1_$2';
         for(String funraiseFieldName : request.keySet()) {
@@ -185,13 +213,70 @@ public class frSubscription extends frModel implements frSyncable {
             if(createLogRecord) frUtil.logException(getFrType(), funraiseId, ex);
             return result;
         }
-        
+
         if(pledgeAmount != null) {
             frPledge.create(subscription, pledgeAmount);
         }
         return result;
     }
-    
+
+    private Boolean createNPSPRecurringDonation(Map<String, Object> request, Contact contact) {
+        Boolean result = false;
+        String funraiseId = getFunraiseId();
+        try {
+            String goalId = String.valueOf(request.get('campaignGoalId'));
+            String query = 'SELECT Id, Name FROM ' + frUtil.NPSP_RECURRING_DONATION_OBJ_NAME
+                + ' WHERE ' + frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME + ' = :funraiseId';
+            List<SObject> records = Database.query(query);
+            SObject recurringDonation = records.isEmpty()
+                ? frUtil.getSObjectType(frUtil.NPSP_RECURRING_DONATION_OBJ_NAME).newSObject()
+                : records.get(0);
+            Map<String, Schema.SObjectField> npspFields = frUtil.getFields(frUtil.NPSP_RECURRING_DONATION_OBJ_NAME);
+
+            putFieldIfExists(recurringDonation, npspFields, frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME, funraiseId);
+            putStringFieldIfExists(recurringDonation, npspFields, 'Name', String.valueOf(request.get('name')));
+            putFieldIfExists(recurringDonation, npspFields, frUtil.NPSP_RECURRING_DONATION_CONTACT_FIELD_NAME, contact.Id);
+
+            if (String.isNotBlank(goalId)) {
+                List<Campaign> campaigns = [SELECT Id FROM Campaign WHERE fr_ID__c = :goalId];
+                if (campaigns.size() > 0) {
+                    putFieldIfExists(recurringDonation, npspFields, frUtil.NPSP_RECURRING_DONATION_CAMPAIGN_FIELD_NAME, campaigns.get(0).Id);
+                } else {
+                    if(createLogRecord) frUtil.logRelationshipError(getFrType(), funraiseId,
+                                                frUtil.Entity.CAMPAIGN, goalId);
+                }
+            }
+
+            applyNPSPRecurringDonationDefaults(recurringDonation, npspFields, request, funraiseId);
+            applyMappings(recurringDonation, request, frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME);
+            Database.upsert(recurringDonation, true);
+            result = true;
+        } catch (Exception ex) {
+            if(createLogRecord) frUtil.logException(getFrType(), funraiseId, ex);
+        }
+        return result;
+    }
+
+    private void applyNPSPRecurringDonationDefaults(
+        SObject recurringDonation,
+        Map<String, Schema.SObjectField> npspFields,
+        Map<String, Object> request,
+        String funraiseId
+    ) {
+        writeRequestFieldIfExists(recurringDonation, npspFields, NPSP_RD_AMOUNT_FIELD_NAME, request, 'amount', funraiseId);
+        writeRequestFieldIfExists(recurringDonation, npspFields, NPSP_RD_DATE_ESTABLISHED_FIELD_NAME, request, 'nextPaymentDate', funraiseId);
+        writeRequestFieldIfExists(recurringDonation, npspFields, NPSP_RD_NEXT_PAYMENT_DATE_FIELD_NAME, request, 'nextPaymentDate', funraiseId);
+        writeRequestFieldIfExists(recurringDonation, npspFields, NPSP_RD_START_DATE_FIELD_NAME, request, 'nextPaymentDate', funraiseId);
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_PAYMENT_METHOD_FIELD_NAME, getNPSPPaymentMethod(request.get('paymentMethodType')));
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_STATUS_FIELD_NAME, getNPSPStatus(request.get('status')));
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_RECURRING_TYPE_FIELD_NAME, 'Open');
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_INSTALLMENT_PERIOD_FIELD_NAME, getNPSPInstallmentPeriod(request.get('frequency')));
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_INSTALLMENT_FREQUENCY_FIELD_NAME, 1);
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_SCHEDULE_TYPE_FIELD_NAME, 'Multiply By');
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_OPEN_ENDED_STATUS_FIELD_NAME, 'Open');
+        putFieldIfExists(recurringDonation, npspFields, NPSP_RD_DAY_OF_MONTH_FIELD_NAME, getNPSPDayOfMonth(request.get('nextPaymentDate')));
+    }
+
     protected override Boolean requireObjectDeletePermission() {
         return true;
     }
@@ -199,21 +284,26 @@ public class frSubscription extends frModel implements frSyncable {
     protected override List<frMapping__c> getMappings() {
         if (frUtil.hasNPCobjects()) {
             return [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = 'Commitment' ORDER BY CreatedDate];
+        } else if(frUtil.usesNPSPRecurringDonations()) {
+            return [SELECT fr_Name__c, sf_Name__c, Is_Constant__c, Constant_Value__c, Conflict_Resolution__c, Type__c FROM frMapping__c WHERE Type__c = :NPSP_RECURRING_DONATION_TYPE ORDER BY CreatedDate];
         } else {
             return new List<frMapping__c>(); // Subscription does not use mappings in non-NPC environments
         }
     }
-    
+
     protected override Set<Schema.SObjectField> getFields() {
         if(frUtil.hasNPCobjects()) {
             Map<String, Schema.SObjectField> fieldMap = Schema.getGlobalDescribe().get('giftcommitment').getDescribe().fields.getMap();
             Set<Schema.SObjectField> usedFields = new Set<Schema.SObjectField>();
             for(frMapping__c mapping : getMappings()) {
-                if(fields.containsKey(mapping.sf_Name__c)) {
-                    usedFields.add(fields.get(mapping.sf_Name__c));
+                if(fieldMap.containsKey(mapping.sf_Name__c)) {
+                    usedFields.add(fieldMap.get(mapping.sf_Name__c));
                 }
             }
             return usedFields;
+        }
+        else if(frUtil.usesNPSPRecurringDonations()) {
+            return getNPSPRecurringDonationFields();
         }
         else{
             return new Set<Schema.SObjectField> {
@@ -247,11 +337,16 @@ public class frSubscription extends frModel implements frSyncable {
             };
         }
     }
-    
+
     protected override Set<Schema.SObjectType> getObjects() {
         if(frUtil.hasNPCobjects()) {
             return new Set<Schema.SObjectType> {
                 Schema.getGlobalDescribe().get('giftcommitment')
+            };
+        }
+        else if(frUtil.usesNPSPRecurringDonations()) {
+            return new Set<Schema.SObjectType> {
+                frUtil.getSObjectType(frUtil.NPSP_RECURRING_DONATION_OBJ_NAME)
             };
         }
         else {
@@ -260,8 +355,137 @@ public class frSubscription extends frModel implements frSyncable {
             };
         }
     }
-    
+
     protected override frUtil.Entity getFrType() {
         return frUtil.Entity.SUBSCRIPTION;
+    }
+
+    private Set<Schema.SObjectField> getNPSPRecurringDonationFields() {
+        Map<String, Schema.SObjectField> npspFields = frUtil.getFields(frUtil.NPSP_RECURRING_DONATION_OBJ_NAME);
+        Set<Schema.SObjectField> usedFields = new Set<Schema.SObjectField>();
+        for(String fieldName : new Set<String>{
+            'Name',
+            frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME,
+            frUtil.NPSP_RECURRING_DONATION_CONTACT_FIELD_NAME,
+            frUtil.NPSP_RECURRING_DONATION_CAMPAIGN_FIELD_NAME,
+            NPSP_RD_AMOUNT_FIELD_NAME,
+            NPSP_RD_DATE_ESTABLISHED_FIELD_NAME,
+            NPSP_RD_DAY_OF_MONTH_FIELD_NAME,
+            NPSP_RD_INSTALLMENT_FREQUENCY_FIELD_NAME,
+            NPSP_RD_INSTALLMENT_PERIOD_FIELD_NAME,
+            NPSP_RD_NEXT_PAYMENT_DATE_FIELD_NAME,
+            NPSP_RD_OPEN_ENDED_STATUS_FIELD_NAME,
+            NPSP_RD_PAYMENT_METHOD_FIELD_NAME,
+            NPSP_RD_RECURRING_TYPE_FIELD_NAME,
+            NPSP_RD_SCHEDULE_TYPE_FIELD_NAME,
+            NPSP_RD_START_DATE_FIELD_NAME,
+            NPSP_RD_STATUS_FIELD_NAME
+        }) {
+            Schema.SObjectField field = npspFields.get(fieldName);
+            if(field != null && field.getDescribe().isCreateable()) {
+                usedFields.add(field);
+            }
+        }
+        for(frMapping__c mapping : getMappings()) {
+            Schema.SObjectField field = npspFields.get(mapping.sf_Name__c);
+            if(field != null) {
+                usedFields.add(field);
+            }
+        }
+        return usedFields;
+    }
+
+    private static void writeRequestFieldIfExists(
+        SObject record,
+        Map<String, Schema.SObjectField> fieldMap,
+        String fieldName,
+        Map<String, Object> request,
+        String requestFieldName,
+        String funraiseId
+    ) {
+        Schema.SObjectField field = fieldMap.get(fieldName);
+        if(field != null && field.getDescribe().isCreateable() && request.containsKey(requestFieldName) && request.get(requestFieldName) != null) {
+            frModel.write(record, field, fieldName, request.get(requestFieldName), funraiseId);
+        }
+    }
+
+    private static void putStringFieldIfExists(
+        SObject record,
+        Map<String, Schema.SObjectField> fieldMap,
+        String fieldName,
+        String value
+    ) {
+        Schema.SObjectField field = fieldMap.get(fieldName);
+        if(field != null && field.getDescribe().isCreateable()) {
+            record.put(field, frUtil.truncateToFieldLength(field.getDescribe(), value));
+        }
+    }
+
+    private static void putFieldIfExists(
+        SObject record,
+        Map<String, Schema.SObjectField> fieldMap,
+        String fieldName,
+        Object value
+    ) {
+        Schema.SObjectField field = fieldMap.get(fieldName);
+        if(field != null && field.getDescribe().isCreateable() && value != null) {
+            record.put(field, value);
+        }
+    }
+
+    @TestVisible
+    private static String getNPSPInstallmentPeriod(Object frequency) {
+        String value = frequency != null ? String.valueOf(frequency).toLowerCase() : '';
+        if(value.contains('week')) {
+            return 'Weekly';
+        }
+        if(value.contains('year') || value.contains('annual')) {
+            return 'Yearly';
+        }
+        if(value.contains('quarter')) {
+            return 'Quarterly';
+        }
+        return 'Monthly';
+    }
+
+    @TestVisible
+    private static String getNPSPStatus(Object status) {
+        String value = status != null ? String.valueOf(status).toLowerCase() : '';
+        if(value.contains('pause')) {
+            return 'Lapsed';
+        }
+        if(value.contains('lapse')) {
+            return 'Lapsed';
+        }
+        if(value.contains('cancel') || value.contains('closed') || value.contains('inactive')) {
+            return 'Closed';
+        }
+        return 'Active';
+    }
+
+    @TestVisible
+    private static String getNPSPPaymentMethod(Object paymentMethod) {
+        String value = paymentMethod != null ? String.valueOf(paymentMethod).toLowerCase() : '';
+        if(String.isBlank(value)) {
+            return null;
+        }
+        if(value.contains('ach') || value.contains('bank')) {
+            return 'ACH';
+        }
+        if(value.contains('check')) {
+            return 'Check';
+        }
+        return 'Credit Card';
+    }
+
+    @TestVisible
+    private static String getNPSPDayOfMonth(Object localDate) {
+        if(localDate instanceof List<Object>) {
+            List<Object> values = (List<Object>) localDate;
+            if(values.size() >= 3 && values.get(2) != null) {
+                return String.valueOf(values.get(2));
+            }
+        }
+        return '15';
     }
 }

--- a/src/classes/frSubscriptionTest.cls
+++ b/src/classes/frSubscriptionTest.cls
@@ -44,32 +44,32 @@ public class frSubscriptionTest {
     // 1) createSubscription_noCampaign
     //
     static testMethod void createSubscription_noCampaign() {
-        if (frUtil.hasNPCobjects()) {
+        if (frUtil.hasNPCobjects() || frUtil.usesNPSPRecurringDonations()) {
             return;
         }
 
         Contact testSupporter = frDonorTest.getTestContact();
-                
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
         request.put('id', funraiseId);
 
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSSubscriptionController.syncEntity();
         Test.stopTest();
-        
-        Subscription__c subscription = [SELECT Id, fr_ID__c, 
-                                        Name, Allocation_Name__c, 
-                                        Amount__c, Campaign_Page_Name__c, Comment__c, 
-                                        Company_Match__c, Company_Match_Company_Name__c, 
-                                        Company_Match_Employee_Email__c, Currency__c, Dedication__c, 
-                                        Dedication_Email__c, Dedication_Message__c, Dedication_Name__c, 
-                                        Dedication_Type__c, Form_Name__c, Frequency__c, 
-                                        Campaign_Goal__c, Imported__c, Next_Payment_Date__c, 
-                                        Note__c, Operations_Tip__c, Payment_Method_Expiration_Date__c, Payment_Method_Last_Four__c, 
+
+        Subscription__c subscription = [SELECT Id, fr_ID__c,
+                                        Name, Allocation_Name__c,
+                                        Amount__c, Campaign_Page_Name__c, Comment__c,
+                                        Company_Match__c, Company_Match_Company_Name__c,
+                                        Company_Match_Employee_Email__c, Currency__c, Dedication__c,
+                                        Dedication_Email__c, Dedication_Message__c, Dedication_Name__c,
+                                        Dedication_Type__c, Form_Name__c, Frequency__c,
+                                        Campaign_Goal__c, Imported__c, Next_Payment_Date__c,
+                                        Note__c, Operations_Tip__c, Payment_Method_Expiration_Date__c, Payment_Method_Last_Four__c,
                                         Payment_Method_Type__c, Status__c, Supporter__c
         FROM Subscription__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(String.valueOf(request.get('name')), subscription.Name, 'The subscription name should be the property included in the request');
@@ -97,9 +97,78 @@ public class frSubscriptionTest {
         System.assertEquals(String.valueOf(request.get('status')), subscription.Status__c, 'The property should be what was provided in the request');
         List<Object> requestPaymentDate = (List<Object>)request.get('nextPaymentDate');
         System.assertEquals(frModel.convertFromLocalDate(requestPaymentDate), subscription.Next_Payment_Date__c, 'The property for next payment date should be what was provided in the request');
-        
+
         System.assertEquals(testSupporter.Id, subscription.Supporter__c, 'The lookup for supporter should have been populated with the contact that has the funraise id referenced in the request');
         System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
+    }
+
+    static testMethod void createSubscription_noCampaign_NPSP() {
+        if (frUtil.hasNPCobjects() || !frUtil.hasNPSPRecurringDonations()) {
+            return;
+        }
+        enableNPSPRecurringDonationTarget();
+
+        Contact testSupporter = frDonorTest.getTestContact();
+
+        String funraiseId = '25';
+        Map<String, Object> request = getTestRequest();
+        request.put('supporterId', testSupporter.fr_ID__c);
+        request.put('id', funraiseId);
+
+        frTestUtil.createTestPost(request);
+
+        Test.startTest();
+        frWSSubscriptionController.syncEntity();
+        Test.stopTest();
+
+        List<String> fields = new List<String>{
+            'Id',
+            'Name',
+            frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME,
+            frUtil.NPSP_RECURRING_DONATION_CONTACT_FIELD_NAME
+        };
+        addFieldIfPresent(fields, 'npe03__Amount__c');
+        addFieldIfPresent(fields, 'npe03__Installment_Period__c');
+        addFieldIfPresent(fields, 'npe03__Status__c');
+        String query = 'SELECT ' + String.join(fields, ',') + ' FROM ' + frUtil.NPSP_RECURRING_DONATION_OBJ_NAME
+            + ' WHERE ' + frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME + ' = :funraiseId';
+        List<SObject> recurringDonations = Database.query(query);
+
+        System.assertEquals(1, recurringDonations.size(), 'NPSP Recurring Donation should have been created');
+        SObject recurringDonation = recurringDonations.get(0);
+        System.assertEquals(String.valueOf(request.get('name')), recurringDonation.get('Name'), 'The recurring donation name should come from the request');
+        System.assertEquals(funraiseId, recurringDonation.get(frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME), 'The NPSP external id should use the Funraise subscription id');
+        System.assertEquals(testSupporter.Id, recurringDonation.get(frUtil.NPSP_RECURRING_DONATION_CONTACT_FIELD_NAME), 'The NPSP contact lookup should be populated from the Funraise supporter');
+        if(fields.contains('npe03__Amount__c') && recurringDonation.get('npe03__Amount__c') != null) {
+            System.assertEquals(Decimal.valueOf(String.valueOf(request.get('amount'))), recurringDonation.get('npe03__Amount__c'), 'The NPSP amount should come from the request');
+        }
+        if(fields.contains('npe03__Installment_Period__c') && recurringDonation.get('npe03__Installment_Period__c') != null) {
+            System.assertEquals('Monthly', recurringDonation.get('npe03__Installment_Period__c'), 'The NPSP installment period should be normalized from the request frequency');
+        }
+        if(fields.contains('npe03__Status__c') && recurringDonation.get('npe03__Status__c') != null) {
+            System.assertEquals('Active', recurringDonation.get('npe03__Status__c'), 'The NPSP status should be normalized from the request status');
+        }
+        System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
+    }
+
+    static testMethod void npspNormalizationHelpers() {
+        System.assertEquals('Monthly', frSubscription.getNPSPInstallmentPeriod(null), 'Blank frequencies should default to monthly');
+        System.assertEquals('Weekly', frSubscription.getNPSPInstallmentPeriod('Every week'), 'Weekly frequencies should be normalized');
+        System.assertEquals('Quarterly', frSubscription.getNPSPInstallmentPeriod('Quarterly'), 'Quarterly frequencies should be normalized');
+        System.assertEquals('Yearly', frSubscription.getNPSPInstallmentPeriod('Annual'), 'Annual frequencies should be normalized');
+
+        System.assertEquals('Active', frSubscription.getNPSPStatus(null), 'Blank statuses should default to active');
+        System.assertEquals('Lapsed', frSubscription.getNPSPStatus('Paused'), 'Paused subscriptions should map to a legacy NPSP status value');
+        System.assertEquals('Lapsed', frSubscription.getNPSPStatus('Lapsed'), 'Lapsed statuses should be normalized');
+        System.assertEquals('Closed', frSubscription.getNPSPStatus('Cancelled'), 'Cancelled statuses should be closed');
+
+        System.assertEquals(null, frSubscription.getNPSPPaymentMethod(null), 'Blank payment methods should stay blank');
+        System.assertEquals('ACH', frSubscription.getNPSPPaymentMethod('Bank Account'), 'Bank payments should be ACH');
+        System.assertEquals('Check', frSubscription.getNPSPPaymentMethod('Check'), 'Check payments should be normalized');
+        System.assertEquals('Credit Card', frSubscription.getNPSPPaymentMethod('Visa'), 'Other payment methods should default to Credit Card');
+
+        System.assertEquals('15', frSubscription.getNPSPDayOfMonth(null), 'Blank dates should default to the 15th day');
+        System.assertEquals('20', frSubscription.getNPSPDayOfMonth(new List<Object>{2019, 6, 20}), 'Local dates should use their day value');
     }
 
     static testMethod void createSubscription_noCampaign_NPC() {
@@ -108,7 +177,7 @@ public class frSubscriptionTest {
         }
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonorTest.getTestAccount(true);
-                
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
@@ -117,7 +186,7 @@ public class frSubscriptionTest {
         if(frUtil.hasNPCobjects()) request.put('supporterId', testAccount.fr_ID__c);
 
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSSubscriptionController.syncEntity();
         Test.stopTest();
@@ -136,22 +205,22 @@ public class frSubscriptionTest {
     //
     // 2) createSubscription_withCampaignGoal
     //
-    static testMethod void createSubscription_withCampaignGoal() {  
-        if (frUtil.hasNPCobjects()) {
+    static testMethod void createSubscription_withCampaignGoal() {
+        if (frUtil.hasNPCobjects() || frUtil.usesNPSPRecurringDonations()) {
             return;
-        }    
+        }
         Contact testSupporter = frDonorTest.getTestContact();
-        
-        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
+
+        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
         request.put('id', funraiseId);
         request.put('campaignGoalId', testCampaign.fr_ID__c);
-        
+
         frTestUtil.createTestPost(request);
 
         Test.startTest();
@@ -168,11 +237,11 @@ public class frSubscriptionTest {
             return;
         }
         Account testAccount = frDonorTest.getTestAccount(true);
-        
-        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
+
+        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('id', funraiseId);
@@ -196,16 +265,16 @@ public class frSubscriptionTest {
     //
     // 3) createSubscription_missingSupporter
     //
-    static testMethod void createSubscription_missingSupporter() {  
+    static testMethod void createSubscription_missingSupporter() {
         Contact testSupporter = frDonorTest.getTestContact();
-        
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c+'1');
         request.put('id', funraiseId);
 
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSSubscriptionController.syncEntity();
         Test.stopTest();
@@ -243,15 +312,15 @@ public class frSubscriptionTest {
     //
     // 4) createSubscription_missingCampaignGoal
     //
-    static testMethod void createSubscription_missingCampaignGoal() {   
-        if (frUtil.hasNPCobjects()) return;
-        
+    static testMethod void createSubscription_missingCampaignGoal() {
+        if (frUtil.hasNPCobjects() || frUtil.usesNPSPRecurringDonations()) return;
+
         Contact testSupporter = frDonorTest.getTestContact();
-        
-        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
+
+        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
@@ -259,7 +328,7 @@ public class frSubscriptionTest {
         request.put('campaignGoalId', testCampaign.fr_ID__c+'1');
 
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSSubscriptionController.syncEntity();
         Test.stopTest();
@@ -274,11 +343,11 @@ public class frSubscriptionTest {
         }
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonorTest.getTestAccount(true);
-        
-        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
+
+        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
@@ -287,7 +356,7 @@ public class frSubscriptionTest {
         if(frUtil.hasNPCobjects()) request.put('supporterId', testAccount.fr_ID__c);
 
         frTestUtil.createTestPost(request);
-        
+
         Test.startTest();
         frWSSubscriptionController.syncEntity();
         Test.stopTest();
@@ -301,14 +370,14 @@ public class frSubscriptionTest {
     //
     // 5) deleteSubscription
     //
-    static testMethod void deleteSubscription() {    
-        if (frUtil.hasNPCobjects()) {
+    static testMethod void deleteSubscription() {
+        if (frUtil.hasNPCobjects() || frUtil.usesNPSPRecurringDonations()) {
             return;
-        }         
+        }
         Contact testSupporter = frDonorTest.getTestContact();
-        
+
         insert new Subscription__c(Name = 'Test Sub', fr_ID__c = '25', Supporter__c = testSupporter.Id);
-        
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
@@ -323,6 +392,34 @@ public class frSubscriptionTest {
 
         Integer matchingRecords = [SELECT COUNT() FROM Subscription__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(0, matchingRecords, 'subscription should have been deleted and therefore not returned');
+        System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
+    }
+
+    static testMethod void deleteSubscription_NPSP() {
+        if (frUtil.hasNPCobjects() || !frUtil.hasNPSPRecurringDonations()) {
+            return;
+        }
+        enableNPSPRecurringDonationTarget();
+
+        Contact testSupporter = frDonorTest.getTestContact();
+        String funraiseId = '25';
+        Map<String, Object> request = getTestRequest();
+        request.put('supporterId', testSupporter.fr_ID__c);
+        request.put('id', funraiseId);
+        frTestUtil.createTestPost(request);
+        frWSSubscriptionController.syncEntity();
+
+        request.put('deleted', true);
+        frTestUtil.createTestPost(request);
+
+        Test.startTest();
+        frWSSubscriptionController.syncEntity();
+        Test.stopTest();
+
+        String query = 'SELECT Id FROM ' + frUtil.NPSP_RECURRING_DONATION_OBJ_NAME
+            + ' WHERE ' + frUtil.NPSP_RECURRING_DONATION_ID_FIELD_NAME + ' = :funraiseId';
+        List<SObject> matchingRecords = Database.query(query);
+        System.assertEquals(0, matchingRecords.size(), 'NPSP Recurring Donation should have been deleted');
         System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
     }
 
@@ -362,23 +459,23 @@ public class frSubscriptionTest {
     // 6) createSubscription_createPledge
     //
     static testMethod void createSubscription_createPledge() {
-        if (frUtil.hasNPCobjects()) {
+        if (frUtil.hasNPCobjects() || frUtil.usesNPSPRecurringDonations()) {
             return;
-        }    
+        }
         Contact testSupporter = frDonorTest.getTestContact();
-                
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
         request.put('id', funraiseId);
         request.put('pledgeAmount', 500);
-        
+
         frTestUtil.createTestPost(request);
 
         Test.startTest();
         frWSSubscriptionController.syncEntity();
         Test.stopTest();
-        
+
         Subscription__c subscription = [SELECT Id, Supporter__c FROM Subscription__c WHERE fr_ID__c = :funraiseId];
         System.assertEquals(testSupporter.Id, subscription.Supporter__c, 'The lookup for supporter should have been populated with the contact that has the funraise id referenced in the request');
         System.assertEquals(0, [SELECT COUNT() FROM Error__c], 'No errors were expected');
@@ -393,11 +490,11 @@ public class frSubscriptionTest {
         }
         Contact testSupporter = frDonorTest.getTestContact();
         Account testAccount = frDonorTest.getTestAccount(true);
-        
-        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign', 
+
+        Campaign testCampaign = new Campaign(fr_ID__c = '10', Name = 'Test Campaign',
                                              ExpectedRevenue = 123, Description = 'Test', Status = 'Published');
         insert testCampaign;
-        
+
         String funraiseId = '25';
         Map<String, Object> request = getTestRequest();
         request.put('supporterId', testSupporter.fr_ID__c);
@@ -409,9 +506,9 @@ public class frSubscriptionTest {
         Test.startTest();
         frWSSubscriptionController.syncEntity();
         Test.stopTest();
-        
+
         List<SObject> gcList = Database.query(
-            'SELECT Id, Name, DonorId ' + 
+            'SELECT Id, Name, DonorId ' +
             'FROM GiftCommitment ' +
             'WHERE fr_ID__c = :funraiseId'
         );
@@ -450,5 +547,25 @@ public class frSubscriptionTest {
         request.put('deleted', false);
         request.put('pledgeAmount', null);
         return request;
+    }
+
+    private static void addFieldIfPresent(List<String> fieldNames, String fieldName) {
+        if(frUtil.getField(frUtil.NPSP_RECURRING_DONATION_OBJ_NAME, fieldName) != null) {
+            fieldNames.add(fieldName);
+        }
+    }
+
+    public static void enableNPSPRecurringDonationTarget() {
+        List<frSetting__c> settings = [
+            SELECT Id, Value__c
+            FROM frSetting__c
+            WHERE Name = :frUtil.SETTING_SUBSCRIPTION_TARGET
+            LIMIT 1
+        ];
+        frSetting__c setting = settings.isEmpty()
+            ? new frSetting__c(Name = frUtil.SETTING_SUBSCRIPTION_TARGET)
+            : settings.get(0);
+        setting.Value__c = frUtil.SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION;
+        upsert setting;
     }
 }

--- a/src/classes/frUtil.cls
+++ b/src/classes/frUtil.cls
@@ -1,9 +1,18 @@
 public class frUtil {
+    public static final String SETTING_SUBSCRIPTION_TARGET = 'Subscription Target';
+    public static final String SUBSCRIPTION_TARGET_FUNRAISE = 'Funraise Subscription';
+    public static final String SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION = 'NPSP Recurring Donation';
+    public static final String NPSP_RECURRING_DONATION_OBJ_NAME = 'npe03__Recurring_Donation__c';
+    public static final String NPSP_RECURRING_DONATION_ID_FIELD_NAME = 'npe03__CommitmentId__c';
+    public static final String NPSP_RECURRING_DONATION_CONTACT_FIELD_NAME = 'npe03__Contact__c';
+    public static final String NPSP_RECURRING_DONATION_ACCOUNT_FIELD_NAME = 'npe03__Organization__c';
+    public static final String NPSP_RECURRING_DONATION_CAMPAIGN_FIELD_NAME = 'npe03__Recurring_Donation_Campaign__c';
+    public static final String NPSP_RECURRING_DONATION_OPPORTUNITY_LOOKUP_FIELD_NAME = 'npe03__Recurring_Donation__c';
     private static String FUNRAISE_ID_FIELD = 'fr_Id__c';
-    public static String truncateToFieldLength(DescribeFieldResult describe, String value) { 
+    public static String truncateToFieldLength(DescribeFieldResult describe, String value) {
         return String.isNotBlank(value) && value.length() > describe.getLength() ? value.substring(0, describe.getLength()) : value;
     }
-    
+
     public static Boolean hasNPSP(){
         try {
             return UserInfo.isCurrentUserLicensed('npsp');
@@ -19,24 +28,69 @@ public class frUtil {
             return false;
         }
     }
-    
+
+    public static Boolean hasNPSPRecurringDonations() {
+        return getSObjectType(NPSP_RECURRING_DONATION_OBJ_NAME) != null
+            && getField(NPSP_RECURRING_DONATION_OBJ_NAME, NPSP_RECURRING_DONATION_ID_FIELD_NAME) != null;
+    }
+
+    public static String getSubscriptionTarget() {
+        List<frSetting__c> settings = [
+            SELECT Value__c
+            FROM frSetting__c
+            WHERE Name = :SETTING_SUBSCRIPTION_TARGET
+            LIMIT 1
+        ];
+        if(!settings.isEmpty() && String.isNotBlank(settings.get(0).Value__c)) {
+            return settings.get(0).Value__c;
+        }
+        return SUBSCRIPTION_TARGET_FUNRAISE;
+    }
+
+    public static Boolean usesNPSPRecurringDonations() {
+        return SUBSCRIPTION_TARGET_NPSP_RECURRING_DONATION.equals(getSubscriptionTarget())
+            && hasNPSPRecurringDonations();
+    }
+
+    public static Schema.SObjectType getSObjectType(String objectName) {
+        if(String.isBlank(objectName)) {
+            return null;
+        }
+        return Schema.getGlobalDescribe().get(objectName.toLowerCase());
+    }
+
+    public static Map<String, Schema.SObjectField> getFields(String objectName) {
+        Schema.SObjectType sObjectType = getSObjectType(objectName);
+        if(sObjectType == null) {
+            return new Map<String, Schema.SObjectField>();
+        }
+        return sObjectType.getDescribe().fields.getMap();
+    }
+
+    public static Schema.SObjectField getField(String objectName, String fieldName) {
+        if(String.isBlank(fieldName)) {
+            return null;
+        }
+        return getFields(objectName).get(fieldName.toLowerCase());
+    }
+
     public static void logRelationshipError(Entity errObject, String recordId, Entity missingRelationship, String relationshipId) {
         logRelationshipError(errObject, recordId, missingRelationship, relationshipId, null);
     }
-    
+
     public static void logRelationshipError(Entity errObject, String recordId, Entity missingRelationship, String relationshipId, String optionalError) {
         String relationshipObject = getObjectFromEnum(missingRelationship);
-        String error = 'Failed to find related record ' + 
+        String error = 'Failed to find related record ' +
                  relationshipObject + ' with Funraise Id: ' + relationshipId;
         if(optionalError != null) {
             error += '. ' + optionalError;
         }
         logError(errObject, recordId, error);
     }
-    
-    private static Set<StatusCode> duplicateValueStatusCodes = 
+
+    private static Set<StatusCode> duplicateValueStatusCodes =
         new Set<StatusCode>{StatusCode.DUPLICATE_EXTERNAL_ID, StatusCode.DUPLICATE_VALUE};
-    
+
     public static void logException(Entity errObject, String recordId, Exception ex) {
         if(ex instanceof DMLException) {
             DMLException dmlEx = (DMLException)ex;
@@ -46,12 +100,12 @@ public class frUtil {
                     logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());
                 }
             }
-            
+
         } else {
-            logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());            
+            logError(errObject, recordId, 'Operation failed. Exception: '+ex.getMessage());
         }
     }
-    
+
     public static void logError(Entity errObject, String recordId, String error) {
 		String funraiseObject = getObjectFromEnum(errObject);
         try {
@@ -59,15 +113,15 @@ public class frUtil {
                 Error__c = frUtil.truncateToFieldLength(Error__c.Error__c.getDescribe(), error),
                 Funraise_Object__c = funraiseObject,
                 Funraise_Object_Id__c = recordId
-            );    
+            );
         } catch (Exception ex) {
             //the only reason this may fail is SF storage limits
             System.debug('Failed to create Funraise Error__c log.  Error dump:');
             System.debug(String.format('Error: {0}, Object: {1}, Object Id: {2}', new List<String>{error, funraiseObject, recordId}));
         }
-        
+
     }
-    
+
     private static String getObjectFromEnum(Entity frObject) {
         String funraiseObject = null;
         if(frObject == Entity.DONATION) {
@@ -101,7 +155,7 @@ public class frUtil {
         }
         return funraiseObject;
     }
-    
+
     public enum Entity {
         DONATION,
         SUPPORTER,
@@ -118,5 +172,5 @@ public class frUtil {
         GIFTCOMMITMENT,
         PERSONACCOUNT
     }
-    
+
 }

--- a/src/objects/frSetting__c.object
+++ b/src/objects/frSetting__c.object
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>List</customSettingsType>
+    <enableFeeds>false</enableFeeds>
+    <fields>
+        <fullName>Value__c</fullName>
+        <deprecated>false</deprecated>
+        <externalId>false</externalId>
+        <label>Value</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <label>Funraise Setting</label>
+    <visibility>Protected</visibility>
+</CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -93,6 +93,7 @@
         <members>Sync_Attempt__c</members>
         <members>frField__mdt</members>
         <members>frMapping__c</members>
+        <members>frSetting__c</members>
         <name>CustomObject</name>
     </types>
     <types>

--- a/src/pages/frSetup.page
+++ b/src/pages/frSetup.page
@@ -3,35 +3,45 @@
     <apex:form >
         <apex:pageBlock title="Instructions" rendered="{!isNonProfitOrg == false}">
             <apex:pageBlockButtons location="top">
-                <apex:commandButton action="{!save}" value="Save Mappings" />
+                <apex:commandButton action="{!save}" value="Save Settings and Mappings" />
                 <apex:commandButton action="{!cancel}" value="Discard Changes" />
                 <apex:commandButton action="{!defaults}" value="Use Default Mappings" onclick="return confirm('This will delete ALL of your current mappings and replace them with the defaults.  Are you sure you want to continue?');" />
             </apex:pageBlockButtons>
             <h2>
-                Use this page to define what fields should be populated when a new donation (opportunity) or donor (contact) is sent from the 
+                Use this page to define what fields should be populated when a new donation (opportunity) or donor (contact) is sent from the
                 Funraise platform
             </h2>
             <br/> <br/>
             <h2>
-                If you would prefer to hardcode a value for an opportunity or contact, check the "Constant?" box and enter the hardcoded value.  
+                If you would prefer to hardcode a value for an opportunity or contact, check the "Constant?" box and enter the hardcoded value.
                 If not, you can select a field value that comes from Funraise
             </h2>
         </apex:pageBlock>
         <apex:pageBlock title="Instructions" rendered="{!isNonProfitOrg == true}">
             <apex:pageBlockButtons location="top">
-                <apex:commandButton action="{!save}" value="Save Mappings" />
+                <apex:commandButton action="{!save}" value="Save Settings and Mappings" />
                 <apex:commandButton action="{!cancel}" value="Discard Changes" />
                 <apex:commandButton action="{!defaults}" value="Use Default Mappings" onclick="return confirm('This will delete ALL of your current mappings and replace them with the defaults.  Are you sure you want to continue?');" />
             </apex:pageBlockButtons>
             <h2>
-                Use this page to define what fields should be populated when a new donation (Gift Transaction) or donor (Person Account) is sent from the 
+                Use this page to define what fields should be populated when a new donation (Gift Transaction) or donor (Person Account) is sent from the
                 Funraise platform
             </h2>
             <br/> <br/>
             <h2>
-                If you would prefer to hardcode a value for an Gift Transaction or Person Account, check the "Constant?" box and enter the hardcoded value.  
+                If you would prefer to hardcode a value for an Gift Transaction or Person Account, check the "Constant?" box and enter the hardcoded value.
                 If not, you can select a field value that comes from Funraise
             </h2>
+        </apex:pageBlock>
+        <apex:pageBlock title="Subscription Target" rendered="{!isNonProfitOrg == false}">
+            <apex:pageBlockSection columns="1">
+                <apex:pageBlockSectionItem>
+                    <apex:outputLabel value="Subscription Target" for="subscriptionTarget" />
+                    <apex:selectList id="subscriptionTarget" value="{!subscriptionTarget}" size="1">
+                        <apex:selectOptions value="{!subscriptionTargetOptions}" />
+                    </apex:selectList>
+                </apex:pageBlockSectionItem>
+            </apex:pageBlockSection>
         </apex:pageBlock>
         <apex:pageBlock title="Donation --> Opportunity" rendered="{!isNonProfitOrg == false}">
             <apex:pageBlockButtons location="top">
@@ -54,7 +64,7 @@
                         <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
                         <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
                             <apex:selectOptions value="{!donationFROptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -62,18 +72,18 @@
                         </apex:facet>
                         <apex:selectList value="{!mapping.sf_Name__c}" size="1">
                             <apex:selectOptions value="{!donationSFOptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
                             Conflict Resolution
                         </apex:facet>
-                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE}" itemLabel="Overwrite Existing Data with Funraise Data" />
                             <apex:selectOption itemValue="{!MAPPING_NO_OVERWRITE}" itemLabel="Do Not Overwrite Existing Data" />
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE_NON_NULL}" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE_RECENT}" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -111,7 +121,7 @@
                         <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
                         <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
                             <apex:selectOptions value="{!donationFROptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -119,18 +129,18 @@
                         </apex:facet>
                         <apex:selectList value="{!mapping.sf_Name__c}" size="1">
                             <apex:selectOptions value="{!donationSFOptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
                             Conflict Resolution
                         </apex:facet>
-                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE}" itemLabel="Overwrite Existing Data with Funraise Data" />
                             <apex:selectOption itemValue="{!MAPPING_NO_OVERWRITE}" itemLabel="Do Not Overwrite Existing Data" />
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE_NON_NULL}" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE_RECENT}" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -168,7 +178,7 @@
                         <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
                         <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
                             <apex:selectOptions value="{!donorFROptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -176,18 +186,18 @@
                         </apex:facet>
                         <apex:selectList value="{!mapping.sf_Name__c}" size="1">
                             <apex:selectOptions value="{!donorSFOptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
                             Conflict Resolution
                         </apex:facet>
-                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">
                             <apex:selectOption itemValue="overwrite" itemLabel="Overwrite Existing Data with Funraise Data" />
                             <apex:selectOption itemValue="do_not_overwrite" itemLabel="Do Not Overwrite Existing Data" />
                             <apex:selectOption itemValue="overwrite_non_null" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
                             <apex:selectOption itemValue="overwrite_more_recent" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -225,7 +235,7 @@
                         <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
                         <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
                             <apex:selectOptions value="{!donorFROptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -233,18 +243,18 @@
                         </apex:facet>
                         <apex:selectList value="{!mapping.sf_Name__c}" size="1">
                             <apex:selectOptions value="{!donorSFOptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
                             Conflict Resolution
                         </apex:facet>
-                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">
                             <apex:selectOption itemValue="overwrite" itemLabel="Overwrite Existing Data with Funraise Data" />
                             <apex:selectOption itemValue="do_not_overwrite" itemLabel="Do Not Overwrite Existing Data" />
                             <apex:selectOption itemValue="overwrite_non_null" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
                             <apex:selectOption itemValue="overwrite_more_recent" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -282,7 +292,7 @@
                         <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
                         <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
                             <apex:selectOptions value="{!giftCommitmentFROptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -290,18 +300,18 @@
                         </apex:facet>
                         <apex:selectList value="{!mapping.sf_Name__c}" size="1">
                             <apex:selectOptions value="{!giftCommitmentSFOptions}" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
                             Conflict Resolution
                         </apex:facet>
-                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">                        
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE}" itemLabel="Overwrite Existing Data with Funraise Data" />
                             <apex:selectOption itemValue="{!MAPPING_NO_OVERWRITE}" itemLabel="Do Not Overwrite Existing Data" />
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE_NON_NULL}" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
                             <apex:selectOption itemValue="{!MAPPING_OVERWRITE_RECENT}" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
-                        </apex:selectList> 
+                        </apex:selectList>
                     </apex:column>
                     <apex:column >
                         <apex:facet name="header">
@@ -315,6 +325,63 @@
                 </apex:pageBlockTable>
                 <apex:commandLink action="{!addMapping}" value="Add Gift Commitment Mapping" reRender="giftcommitmentTable">
                     <apex:param name="type" value="{!GIFT_COMMITMENT_TYPE}" />
+                </apex:commandLink>
+            </apex:pageBlockSection>
+        </apex:pageBlock>
+        <apex:pageBlock title="Subscription --> NPSP Recurring Donation" rendered="{!npspRecurringDonationsEnabled == true}">
+            <apex:pageBlockButtons location="top">
+                <apex:commandButton action="{!npspRecurringDonationDefaults}" value="Use Default Mappings" onclick="return confirm('This will delete your current mappings for NPSP Recurring Donation and replace them with the defaults.  Are you sure you want to continue?');" />
+            </apex:pageBlockButtons>
+            <apex:pageBlockSection columns="1">
+                <apex:pageBlockTable value="{!npspRecurringDonationMappings}" var="mapping" id="npspRecurringDonationTable" >
+                    <apex:column >
+                        <apex:facet name="header">
+                            Constant?
+                        </apex:facet>
+                        <apex:inputField value="{!mapping.Is_Constant__c}" >
+                            <apex:actionSupport event="onchange" reRender="npsp-rd-fr-field-column" />
+                        </apex:inputField>
+                    </apex:column>
+                    <apex:column id="npsp-rd-fr-field-column">
+                        <apex:facet name="header">
+                            Value
+                        </apex:facet>
+                        <apex:inputField value="{!mapping.Constant_Value__c}" rendered="{!mapping.Is_Constant__c}" />
+                        <apex:selectList value="{!mapping.fr_Name__c}" size="1" rendered="{!!mapping.Is_Constant__c}">
+                            <apex:selectOptions value="{!npspRecurringDonationFROptions}" />
+                        </apex:selectList>
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Recurring Donation Field
+                        </apex:facet>
+                        <apex:selectList value="{!mapping.sf_Name__c}" size="1">
+                            <apex:selectOptions value="{!npspRecurringDonationSFOptions}" />
+                        </apex:selectList>
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Conflict Resolution
+                        </apex:facet>
+                        <apex:selectList value="{!mapping.Conflict_Resolution__c}" size="1">
+                            <apex:selectOption itemValue="{!MAPPING_OVERWRITE}" itemLabel="Overwrite Existing Data with Funraise Data" />
+                            <apex:selectOption itemValue="{!MAPPING_NO_OVERWRITE}" itemLabel="Do Not Overwrite Existing Data" />
+                            <apex:selectOption itemValue="{!MAPPING_OVERWRITE_NON_NULL}" itemLabel="Only Overwrite Existing Data if Funraise Data is not empty" />
+                            <apex:selectOption itemValue="{!MAPPING_OVERWRITE_RECENT}" itemLabel="Only Overwrite Existing Data if Funraise record was updated more recently" />
+                        </apex:selectList>
+                    </apex:column>
+                    <apex:column >
+                        <apex:facet name="header">
+                            Remove
+                        </apex:facet>
+                        <apex:commandLink action="{!removeMapping}" value="Remove" rendered="{!mapping.id != null}">
+                            <apex:param name="id" value="{!mapping.Id}" />
+                            <apex:param name="type" value="{!NPSP_RECURRING_DONATION_TYPE}" />
+                        </apex:commandLink>
+                    </apex:column>
+                </apex:pageBlockTable>
+                <apex:commandLink action="{!addMapping}" value="Add NPSP Recurring Donation Mapping" reRender="npspRecurringDonationTable">
+                    <apex:param name="type" value="{!NPSP_RECURRING_DONATION_TYPE}" />
                 </apex:commandLink>
             </apex:pageBlockSection>
         </apex:pageBlock>


### PR DESCRIPTION
## Summary
- Adds NPSP Recurring Donation support for subscription sync in non-NPC orgs, but keeps the existing Funraise `Subscription__c` object as the default target.
- Adds a setup-page Subscription Target selector backed by a protected `frSetting__c` setting so admins explicitly opt into NPSP Recurring Donation.
- Routes subscription create/delete/mappings and donation Opportunity subscription links through the selected target instead of NPSP detection alone.
- Adds setup-page mapping/default support for NPSP Recurring Donation fields while preserving existing NPC GiftCommitment behavior.
- Hardens the NPSP path by requiring the `npe03__CommitmentId__c` external id field, catching schema/query exceptions, avoiding direct Organization writes from Contact.AccountId, and mapping paused statuses to legacy NPSP `Lapsed`.

## Testing
- `git diff --check`
- `sf project deploy start --metadata-dir /tmp/funraise-salesforce-FUN-17286-mdapi.* --target-org sandbox --dry-run --test-level NoTestRun --wait 10 --concise --json` succeeded.
- `sf project deploy start --metadata-dir /tmp/funraise-salesforce-FUN-17286-tests.* --target-org sandbox --dry-run --test-level RunSpecifiedTests --tests frSetupControllerTest --tests frSubscriptionTest --tests frDonationTest --wait 20 --concise --json` failed before requested tests executed because the sandbox has unrelated invalid Apex: `frOpportunityLineItemTrigger` / `frOpportunityTrigger` via `frBaseController.save(List<frIntegrationLog>)`.
- Claude Opus read-only review completed; actionable findings were addressed where they were in scope for this branch.

## Notes
The connected sandbox does not have NPSP installed, so NPSP-specific runtime tests remain gated and require an NPSP-enabled org for execution/coverage validation.
